### PR TITLE
Added blurb for Fedora - tested on Fedora 15, x86_64 but should also work

### DIFF
--- a/README
+++ b/README
@@ -16,6 +16,9 @@ http://launchpad.net/pyreadline/trunk/1.7/+download/pyreadline-1.7.win32.exe
 On Ubuntu/debian, do:
 sudo apt-get install python-serial python-wxgtk2.8
 
+On Fedora 15 do:
+sudo yum install pyserial wxpython
+
 On Mac OS X, download and install:
 http://downloads.sourceforge.net/wxpython/wxPython2.8-osx-unicode-2.8.12.0-universal-py2.6.dmg
 Grab the source for pyserial from http://pypi.python.org/packages/source/p/pyserial/pyserial-2.5.tar.gz


### PR DESCRIPTION
Added blurb for Fedora - tested on Fedora 15, x86_64 but should also work on older versions.
