### PR TITLE
Do not try to parse DEBUG_ lines from Sprinter

### DIFF
--- a/printcore.py
+++ b/printcore.py
@@ -86,6 +86,8 @@ class printcore():
                         pass
                 if self.loud:
                     print "RECV: ",line.rstrip()
+            if(line.startswith('DEBUG_')):
+                continue
             if(line.startswith('start') or line.startswith('ok')):
                 self.clear=True
             if(line.startswith('start') or line.startswith('ok') or "T:" in line):


### PR DESCRIPTION
Printcore was trying to parse all lines from firmware, including DEBUG_*, and it failed for example when finding the substring "rs" (as "resend") in the word "Errors".
