### PR TITLE
fixes freezing issue

### DIFF
--- a/printcore.py
+++ b/printcore.py
@@ -76,9 +76,12 @@ class printcore():
         while(True):
             if(not self.printer or not self.printer.isOpen):
                 break
-            line=self.printer.readline()
+            try:
+                line=self.printer.readline()
+            except:
+                line=''
             if(len(line)>1):
-                self.log+=[line]
+                self.log+=[{'Line': self.lineno, 'Response': line, 'Time': time.time()}]
                 if self.recvcb is not None:
                     try:
                         self.recvcb(line)
@@ -86,6 +89,10 @@ class printcore():
                         pass
                 if self.loud:
                     print "RECV: ",line.rstrip()
+            elif self.printing and time.time()-self.log[-1]['Time'] > self.printer.timeout/1000:
+                if self.loud:
+                    print 'Timed out on line '+repr(self.lineno)+', continuing...'
+                self.clear=True
             if(line.startswith('DEBUG_')):
                 continue
             if(line.startswith('start') or line.startswith('ok')):


### PR DESCRIPTION
Hey guys,
I shied away from Printrun for a long time because the print would just pause randomly in the middle of the print and there was no way in pronterface to get it started again, so I was never able to finish any prints with Printrun. It happened with Repsnapper too, but there is a kick button that would continue the print.

Finally today I decided to really buckle down and debug the issue. Fortunately printcore.py is pretty short and sweet. I did some dry runs with printcore and discovered that the print would stop when the software sent a command and didn't receive a response from the printer. In these cases, all I had to do to get the print going again was to set clear to True.

Long story short, I set a timeout. If nothing is added to the log for 5 ms, set clear to True to kick it back to life. I havent had any permanent pauses since my change and things are printing out perfectly! The only downside is that it still pauses sometimes for up to a few seconds (still don't understand why that's happening) but at least the pauses aren't permanent. I hope you add this or something like it to the master branch.
Thanks guys,
Brad
