### PR TITLE
Added 250000 baud for marlin compatibility

### DIFF
--- a/pronterface.py
+++ b/pronterface.py
@@ -379,7 +379,7 @@ class PronterWindow(wx.Frame,pronsole.pronsole):
         uts.Add(self.serialport)
         uts.Add(wx.StaticText(self.panel,-1,"@",pos=(250,5)),wx.RIGHT,5)
         self.baud = wx.ComboBox(self.panel, -1,
-                choices=["2400", "9600", "19200", "38400", "57600", "115200"],
+                choices=["2400", "9600", "19200", "38400", "57600", "115200", "250000"],
                 style=wx.CB_DROPDOWN|wx.CB_SORT|wx.CB_READONLY, size=(110,30),pos=(275,0))
         try:
             self.baud.SetValue("115200")


### PR DESCRIPTION
After the new UI change the baudrate went from a text box to a drop down.  Marlin comes standard at 250000 baud which wasn’t included as a choice.
