### PR TITLE
Improved status line estimated time remaining.

### DIFF
--- a/pronterface.py
+++ b/pronterface.py
@@ -1085,18 +1085,25 @@ class PronterWindow(wx.Frame,pronsole.pronsole):
                 #    self.tgauge.SetValue(int(filter(lambda x:x.startswith("T:"),self.tempreport.split())[0].split(":")[1]))
                 #except:
                 #    pass
+                fractioncomplete = 0.0
                 if self.sdprinting:
+                    fractioncomplete = float(self.percentdone/100.0)
                     string+= _(" SD printing:%04.2f %%") % (self.percentdone,)
                 if self.p.printing:
-                    secondselapsed = int(time.time()-self.starttime)
                     fractioncomplete = float(self.p.queueindex)/len(self.p.mainqueue)
+                    string+= _(" Printing:%04.2f %% |") % (100*float(self.p.queueindex)/len(self.p.mainqueue),)
+                    string+= _(" Line# ") + str(self.p.queueindex) + _("of ") + str(len(self.p.mainqueue)) + _(" lines |" )
+                if fractioncomplete > 0.0:
+                    secondselapsed = int(time.time()-self.starttime)
                     secondsestimate = secondselapsed/fractioncomplete
                     secondsremain = secondsestimate - secondselapsed
-                    string+= _(" Printing:%04.2f %%") % (100*float(self.p.queueindex)/len(self.p.mainqueue),)
-                    string+= _(" Estimated:%02.0f") % (int(secondsremain/60),)
-                    string+= _(":%02.0f") % (int(secondsremain%60),)
-                    string+= _(" of %02.0f") % (int(secondsestimate/60),)
-                    string+= _(":%02.0f Remaining") % (int(secondsestimate%60),)
+                    string+= _(" Est: ") + time.strftime('%H:%M:%S', time.gmtime(secondsremain))
+                    string+= _(" of: ") + time.strftime('%H:%M:%S', time.gmtime(secondsestimate))
+                    string+= _(" Remaining")
+                    #string+= _(" Est:%02.0f") % (int(secondsremain/60),)
+                    #string+= _(":%02.0f") % (int(secondsremain%60),)
+                    #string+= _(" of %02.0f") % (int(secondsestimate/60),)
+                    #string+= _(":%02.0f Remaining") % (int(secondsestimate%60),)
                 wx.CallAfter(self.status.SetStatusText,string)
                 wx.CallAfter(self.gviz.Refresh)
                 if(self.monitor and self.p.online):


### PR DESCRIPTION
uses format:
SD Printing: pp.p% | Est: hh:mm:ss of hh:mm:ss of hh:mm:ss remaining
Printing: pp.p% | @ Line# xxx of yyyyy lines | Est: hh:mm:ss of hh:mm:ss remaining
