### PR TITLE
Somewhat-fixes the scroll wheel rotation.

### DIFF
--- a/plater.py
+++ b/plater.py
@@ -193,6 +193,9 @@ class stlwin(wx.Frame):
         #self.mainsizer.AddSpacer(10)
         if glview:
             self.s=stlview.TestGlPanel(self,(580,580))
+            #Initialise the old showstl for the rotation, but don't show it.
+            self.d=showstl(self,(0,0),(0,0))
+            self.Bind(wx.EVT_MOUSEWHEEL,self.d.rot)
         else:
             self.s=showstl(self,(580,580),(0,0))
         self.mainsizer.Add(self.s, 1, wx.EXPAND)


### PR DESCRIPTION
The scroll wheel listener bind didn't seem to be picking up anything, so I started an instance of the old showstl to handle the scroll wheel. Dodgy hack, but highlights what's broken. It'll work for me until it gets fixed properly.
