### PR TITLE
Added min/max endstop preflight check.

### DIFF
--- a/pronsole.py
+++ b/pronsole.py
@@ -69,6 +69,23 @@ def measurements(g):
         
     return (Xtot,Ytot,Ztot,Xmin,Xmax,Ymin,Ymax,Zmin,Zmax)
 
+def checkbounds (machine=[], xmin=0.0, ymin=0.0, zmin=0.0, xmax=0.0, ymax=0.0, zmax=0.0):
+    warn = False
+    msg = ""
+
+    axis = ("X", "Y", "Z")
+    gmnmx = ((xmin, xmax), (ymin, ymax), (zmin, zmax))
+    mmnmx = ((machine[0], machine[3]), (machine[1],machine[4]), (machine[2], machine[5]))
+    for a, (gmn, gmx), (mmn, mmx) in zip(axis, gmnmx, mmnmx):
+        if gmn < mmn:
+            msg += "{1: >8.2f} is past the {0}-min endstop @ {2: >8.2f}\n".format(a, gmn, mmn)
+            warn = True
+        if gmx > mmx:
+            msg += "{1: >8.2f} is past the {0}-max endstop @ {2: >8.2f}\n".format(a, gmx, mmx)
+            warn = True
+
+    return warn, msg
+
 def totalelength(g):
     tot=0
     cur=0

--- a/pronterface.py
+++ b/pronterface.py
@@ -59,6 +59,8 @@ class PronterWindow(wx.Frame,pronsole.pronsole):
         self.settings.last_bed_temperature = 0.0
         self.settings.bed_size_x = 200.
         self.settings.bed_size_y = 200.
+        self.settings.buildvolume = (0.0,0.0,0.0,self.settings.bed_size_x,self.settings.bed_size_y,120.0)
+        #self.settings.buildorigin = (0.0,0.0,0.0)
         self.settings.preview_grid_step1 = 10.
         self.settings.preview_grid_step2 = 50.
         self.settings.preview_extrusion_width = 0.5
@@ -1305,6 +1307,16 @@ class PronterWindow(wx.Frame,pronsole.pronsole):
         print _("the print goes from"),Ymin,_("mm to"),Ymax,_("mm in Y\nand is"),Ytot,_("mm wide\n")
         print _("the print goes from"),Zmin,_("mm to"),Zmax,_("mm in Z\nand is"),Ztot,_("mm high\n")
         print _("Estimated duration (pessimistic): "), pronsole.estimate_duration(self.f)
+        self.settings.buildvolume = (0.0,0.0,0.0,self.settings.bed_size_x,self.settings.bed_size_y,120.0)
+        iswarning, warningstring = pronsole.checkbounds(self.settings.buildvolume, Xmin, Ymin, Zmin, Xmax, Ymax, Zmax)
+        if iswarning:
+            print _("\n\n>>>> !!!WARNING!!! <<<<\n")
+            print _(warningstring)
+            print _("Printing past the endstops can have ")
+            print _("minor or even catastrophic side effects!")
+            print _("Proceed with caution.")
+            print _("\n>>>> !!!WARNING!!! <<<<\n\n")
+
         self.gviz.clear()
         self.gwindow.p.clear()
         for i in self.f:


### PR DESCRIPTION
(sorry for my git newbness... I didn't know how to separate out my 2 pull requests.  this one is in a branch called BoundaryCheck)...and shouldn't have included "Reduced the amount of data emitted to the user)

issues a warning and tells user how far outside the boundaries the gcode travels.  this should help them find the problem (most likely it's manual gcode homing in their start.gcode, or the model is too big for the print bed.

Warning immediately follows the time estimate,
and is the last thing user sees after loading the file.
here is an example:

> > > > !!!WARNING!!! <<<<

   -1.00 is past the Z-min endstop @     0.00

Printing past the endstops can have
minor or even catastrophic side effects!
Proceed with caution.

> > > > !!!WARNING!!! <<<<
