### PR TITLE
Minor fixes

### DIFF
--- a/pronterface.py
+++ b/pronterface.py
@@ -1551,11 +1551,11 @@ class PronterWindow(wx.Frame,pronsole.pronsole):
         dlg=wx.MessageDialog(self, _("Are you sure you want to reset the printer?"), _("Reset?"), wx.YES|wx.NO)
         if dlg.ShowModal()==wx.ID_YES:
             self.p.reset()
+            self.p.printing=0
+            wx.CallAfter(self.printbtn.SetLabel, _("Print"))
             if self.paused:
                 self.p.paused=0
-                self.p.printing=0
                 wx.CallAfter(self.pausebtn.SetLabel, _("Pause"))
-                wx.CallAfter(self.printbtn.SetLabel, _("Print"))
                 self.paused=0
     
     def get_build_dimensions(self,bdim):


### PR DESCRIPTION
Here are two minor fixes :
- reset "is printing" status when printer is reset (you can perfectly hit the Reset button without hitting Pause first, which was a condition to reset the print status before)
- in temperatures status display, replace "B:" and "T:" instead of "B" and "T" since there might be some mixup otherwise (for instance, "T" is translated to "Buse", so that the B is then replaced twice, once for the temperature info and once for the B in "Buse")
