### PR TITLE
Experimental

### DIFF
--- a/pronsole.py
+++ b/pronsole.py
@@ -1152,11 +1152,13 @@ class pronsole(cmd.Cmd):
         try:
             import shlex
             if(settings):
-                param = self.expandcommand(self.settings.sliceoptscommand).replace("\\","\\\\").encode()
+                sliceComm = self.settings.sliceoptscommand.replace('<port>', self.serialport.GetValue())
+                param = self.expandcommand(sliceComm).replace("\\","\\\\").encode()
                 print "Entering slicer settings: ",param
                 subprocess.call(shlex.split(param))
             else:
-                param = self.expandcommand(self.settings.slicecommand).encode()
+                sliceComm = self.settings.slicecommand.replace('<port>', self.serialport.GetValue())
+                param = self.expandcommand(sliceComm).encode()
                 print "Slicing: ",param
                 params=[i.replace("$s",l[0]).replace("$o",l[0].replace(".stl","_export.gcode").replace(".STL","_export.gcode")).encode() for i in shlex.split(param.replace("\\","\\\\").encode())]
                 subprocess.call(params)

--- a/pronterface.py
+++ b/pronterface.py
@@ -1442,7 +1442,8 @@ class PronterWindow(wx.Frame,pronsole.pronsole):
     def skein_func(self):
         try:
             import shlex
-            param = self.expandcommand(self.settings.slicecommand).encode()
+            tSliceCom = self.settings.slicecommand.replace('<port>', self.serialport.GetValue())
+            param = self.expandcommand(tSliceCom).encode()
             print "Slicing: ",param
             if webavail:
                 self.webInterface.AddLog("Slicing: "+param)


### PR DESCRIPTION
I added a patch to pronterface/pronsole for multiple config files being dynamically selected based on port.

To use:
   In Pronterface Options, in slicecommand, or slicecommandopts, use &lt;port&gt; as part of the file name.

&lt;port&gt; will get replaced with the port you are connected to.

So, config.ini.<port>, will look for config.ini.COM5 if you are connected to COM5, and config.ini.COM8 if you are connected to COM8.
