### PR TITLE
Fixed crash when distance is negative (crash occurs on line 166)

### DIFF
--- a/pronsole.py
+++ b/pronsole.py
@@ -163,7 +163,7 @@ def estimate_duration(g):
                     currenttravel -= distance
                     moveduration += currenttravel/f
                 else:
-                    moveduration = math.sqrt( 2 * distance / acceleration )
+                    moveduration = math.sqrt( 2 * math.fabs(distance) / acceleration )
 
             totalduration += moveduration
 


### PR DESCRIPTION
I don't think this is the correct fix - distance should never be negative. However, this does get around the crash that occurs when this file is loaded:
http://uppit.com/deak3bcz8m0j/ExampleCrash.gcode
