### PR TITLE
Patching the load command so that it works with the pronterface ui

### DIFF
--- a/pronsole.py
+++ b/pronsole.py
@@ -621,6 +621,9 @@ class pronsole(cmd.Cmd):
         print "Disconnects from the printer"
     
     def do_load(self,l):
+      self._do_load(l)
+
+    def _do_load(self,l):
         if len(l)==0:
             print "No file name given."
             return
@@ -631,7 +634,7 @@ class pronsole(cmd.Cmd):
         self.f=[i.replace("\n","").replace("\r","") for i in open(l)]
         self.filename=l
         print "Loaded ",l,", ",len(self.f)," lines."
-        
+
     def complete_load(self, text, line, begidx, endidx):
         s=line.split()
         if len(s)>2:

--- a/pronterface.py
+++ b/pronterface.py
@@ -173,6 +173,8 @@ class PronterWindow(wx.Frame,pronsole.pronsole):
             self.webInterface=webinterface.WebInterface(self)
             self.webThread = Thread(target=webinterface.StartWebInterfaceThread, args=(self.webInterface, ))
             self.webThread.start()
+        if(self.filename is not None):
+          self.do_load(self.filename)
 
     def startcb(self):
         self.starttime=time.time()
@@ -1553,6 +1555,12 @@ class PronterWindow(wx.Frame,pronsole.pronsole):
         self.skeining=1
         thread(target=self.skein_func).start()
         thread(target=self.skein_monitor).start()
+
+    def do_load(self,l):
+      if hasattr(self, 'skeining'):
+        self.loadfile(None, l)
+      else:
+        self._do_load(l)
 
     def loadfile(self,event,filename=None):
         if self.skeining and self.skeinp is not None:


### PR DESCRIPTION
The load command wasn't updating the pronterface ui when used from the command line (ie. ./pronterface -e "load myfile.gcode") or from the printer interface window.

This pull request fixes that by overriding the do_load method in pronterface.py so that it updates the ui once it's loaded. If do_load is called before the window is initialized then the filename is set and later used to load the file to the ui once the window is initialized.
