### PR TITLE
Refactor the README to make packaged binaries more obvious

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,80 +5,44 @@ Printrun consists of printcore, pronsole and pronterface, and a small collection
   * pronterface.py is a graphical host software with the same functionality as pronsole
   * webinterface.py is a browser-usable remote control function for Pronterface
 
-# INSTALLING DEPENDENCIES
+# GETTING PRINTRUN
+
+This section suggests using precompiled binaries, this way you get everything bundled into one single package for an easy installation.
+
+If you want the newest, shiniest features, you can run Printrun from source using the instructions further down this README.
 
 ## Windows
 
 A precompiled version is available at http://koti.kapsi.fi/~kliment/printrun/
 
-Download the following, and install in this order:
+## Mac OS X
 
-  1. http://python.org/ftp/python/2.7.2/python-2.7.2.msi
-  2. http://pypi.python.org/packages/any/p/pyserial/pyserial-2.5.win32.exe
-  3. http://downloads.sourceforge.net/wxpython/wxPython2.8-win32-unicode-2.8.12.0-py27.exe
-  4. http://launchpad.net/pyreadline/1.7/1.7/+download/pyreadline-1.7.win32.exe
-  5. http://pyglet.googlecode.com/files/pyglet-1.1.4.zip
+A precompiled version is available at http://koti.kapsi.fi/~kliment/printrun/
 
-For the last one, you will need to unpack it, open a command terminal, 
-go into the the directory you unpacked it in and run
-`python setup.py install`
+## Linux
+### Ubuntu/Debian
 
-## Ubuntu/Debian
+You can run Printrun directly from source, as there are no packages available yet. Fetch and install the dependencies using
+
 `sudo apt-get install python-serial python-wxgtk2.8 python-pyglet`
 
-## Fedora 15
+### Fedora 15 and newer
+
+You can run Printrun directly from source, as there are no packages available yet. Fetch and install the dependencies using
+
 `sudo yum install pyserial wxpython pyglet`
 
-## Mac OS X Lion
+### Archlinux
 
-A precompiled version is available at http://koti.kapsi.fi/~kliment/printrun/
+Packages are available in AUR. Just run
 
-  1. Ensure that the active Python is the system version. (`brew uninstall python` or other appropriate incantations)
-  2. Download an install [wxPython2.8-osx-unicode] matching to your python version (most likely 2.7 on Lion, 
-        check with: python --version) from: http://wxpython.org/download.php#stable
-  Known to work PythonWX: http://superb-sea2.dl.sourceforge.net/project/wxpython/wxPython/2.8.12.1/wxPython2.8-osx-unicode-2.8.12.1-universal-py2.7.dmg
-  3. Download and unpack pyserial from http://pypi.python.org/packages/source/p/pyserial/pyserial-2.5.tar.gz
-  4. In a terminal, change to the folder you unzipped to, then type in: `sudo python setup.py install`
-  5. Repeat 4. with http://http://pyglet.googlecode.com/files/pyglet-1.1.4.zip
+`yaourt printrun`
 
-The tools will probably run just fine in 64bit on Lion, you don't need to mess
-with any of the 32bit settings. In case they don't, try 
-  5. export VERSIONER_PYTHON_PREFER_32_BIT=yes
-in a terminal before running Pronterface
-
-## Mac OS X (pre Lion)
-
-A precompiled version is available at http://koti.kapsi.fi/~kliment/printrun/
-
-  1. Download and install http://downloads.sourceforge.net/wxpython/wxPython2.8-osx-unicode-2.8.12.0-universal-py2.6.dmg
-  2. Grab the source for pyserial from http://pypi.python.org/packages/source/p/pyserial/pyserial-2.5.tar.gz
-  3. Unzip pyserial to a folder. Then, in a terminal, change to the folder you unzipped to, then type in:
-     
-     `defaults write com.apple.versioner.python Prefer-32-Bit -bool yes`
-     
-     `sudo python setup.py install`
-
-Alternatively, you can run python in 32 bit mode by setting the following environment variable before running the setup.py command:
-
-This alternative approach is confirmed to work on Mac OS X 10.6.8. 
-
-`export VERSIONER_PYTHON_PREFER_32_BIT=yes`
-
-`sudo python setup.py install`
-
-Then repeat the same with http://http://pyglet.googlecode.com/files/pyglet-1.1.4.zip
+and enjoy the `pronterface`, `pronsole`, ... commands directly.
 
 # USING PRONTERFACE
 
-To use pronterface, you need:
-
-  * python (ideally 2.6.x or 2.7.x),
-  * pyserial (or python-serial on ubuntu/debian),
-  * pyglet
-  * pyreadline (not needed on Linux) and
-  * wxPython
-
-Download and install the above, and start pronterface.py
+When you're done setting up Printrun, you can start pronterface.py in the directory you unpacked it.
 Select the port name you are using from the first drop-down, select your baud rate, and hit connect.
 Load an STL (see the note on skeinforge below) or GCODE file, and you can upload it to SD or print it directly.
 The "monitor printer" function, when enabled, checks the printer state (temperatures, SD print progress) every 3 seconds.
@@ -132,6 +96,73 @@ sender, or the following code example:
     p.pause()
     p.resume()
     p.disconnect()
+
+# RUNNING FROM SOURCE
+
+Run Printrun for source if you want to test out the latest features.
+
+## Dependencies
+
+To use pronterface, you need:
+
+  * python (ideally 2.6.x or 2.7.x),
+  * pyserial (or python-serial on ubuntu/debian),
+  * pyglet
+  * pyreadline (not needed on Linux) and
+  * wxPython
+
+Please see specific instructions for Windows and Mac OS X below. Under Linux, you should use your package manager directly (see the "GETTING PRINTRUN" section)
+
+## Windows
+
+Download the following, and install in this order:
+
+  1. http://python.org/ftp/python/2.7.2/python-2.7.2.msi
+  2. http://pypi.python.org/packages/any/p/pyserial/pyserial-2.5.win32.exe
+  3. http://downloads.sourceforge.net/wxpython/wxPython2.8-win32-unicode-2.8.12.0-py27.exe
+  4. http://launchpad.net/pyreadline/1.7/1.7/+download/pyreadline-1.7.win32.exe
+  5. http://pyglet.googlecode.com/files/pyglet-1.1.4.zip
+
+For the last one, you will need to unpack it, open a command terminal, 
+go into the the directory you unpacked it in and run
+`python setup.py install`
+
+## Mac OS X Lion
+
+  1. Ensure that the active Python is the system version. (`brew uninstall python` or other appropriate incantations)
+  2. Download an install [wxPython2.8-osx-unicode] matching to your python version (most likely 2.7 on Lion, 
+        check with: python --version) from: http://wxpython.org/download.php#stable
+  Known to work PythonWX: http://superb-sea2.dl.sourceforge.net/project/wxpython/wxPython/2.8.12.1/wxPython2.8-osx-unicode-2.8.12.1-universal-py2.7.dmg
+  3. Download and unpack pyserial from http://pypi.python.org/packages/source/p/pyserial/pyserial-2.5.tar.gz
+  4. In a terminal, change to the folder you unzipped to, then type in: `sudo python setup.py install`
+  5. Repeat 4. with http://http://pyglet.googlecode.com/files/pyglet-1.1.4.zip
+
+The tools will probably run just fine in 64bit on Lion, you don't need to mess
+with any of the 32bit settings. In case they don't, try 
+  5. export VERSIONER_PYTHON_PREFER_32_BIT=yes
+in a terminal before running Pronterface
+
+## Mac OS X (pre Lion)
+
+A precompiled version is available at http://koti.kapsi.fi/~kliment/printrun/
+
+  1. Download and install http://downloads.sourceforge.net/wxpython/wxPython2.8-osx-unicode-2.8.12.0-universal-py2.6.dmg
+  2. Grab the source for pyserial from http://pypi.python.org/packages/source/p/pyserial/pyserial-2.5.tar.gz
+  3. Unzip pyserial to a folder. Then, in a terminal, change to the folder you unzipped to, then type in:
+     
+     `defaults write com.apple.versioner.python Prefer-32-Bit -bool yes`
+     
+     `sudo python setup.py install`
+
+Alternatively, you can run python in 32 bit mode by setting the following environment variable before running the setup.py command:
+
+This alternative approach is confirmed to work on Mac OS X 10.6.8. 
+
+`export VERSIONER_PYTHON_PREFER_32_BIT=yes`
+
+`sudo python setup.py install`
+
+Then repeat the same with http://http://pyglet.googlecode.com/files/pyglet-1.1.4.zip
 
 # LICENSE
 


### PR DESCRIPTION
Following the discussion on IRC, I made the precompiled version more obvious, keeping the "source" instructions further down the file.

Enjoy!
