### PR TITLE
Fixed a bug on windows that caused find to fail by a few spaces.

### DIFF
--- a/printrun/pronterface_widgets.py
+++ b/printrun/pronterface_widgets.py
@@ -43,7 +43,7 @@ class macroed(wx.Dialog):
         titlesizer.Add(self.cancelb)
         topsizer = wx.BoxSizer(wx.VERTICAL)
         topsizer.Add(titlesizer, 0, wx.EXPAND)
-        self.e = wx.TextCtrl(self.panel, style = wx.TE_MULTILINE+wx.HSCROLL, size = (400, 400))
+        self.e = wx.TextCtrl(self.panel, style = wx.HSCROLL|wx.TE_MULTILINE|wx.TE_RICH2, size = (400, 400))
         if not self.gcode:
             self.e.SetValue(self.unindent(definition))
         else:


### PR DESCRIPTION
here is a link to the explanation of why this bug exists.
http://wiki.wxpython.org/wxPython%20Platform%20Inconsistencies#line-142

Rich Text

The wxTE_RICH style does not work properly under all versions of MSW. Among other issues, GetInsertionPoint() on a multiline text control reports is off by the number of newlines that precede the cursor position. Robin Dunn's recommendation was to use wxTE_RICH2, which solves this particular problem. When asked what this style was, Robin replied:

"It just specifies that a different version of the native control should be used on win32. It's ignored on other platforms."
However, On Fri, 31 Jan 2003 , Vadim Zeitlin wrote:

```
On Fri, 31 Jan 2003 13:27:25 Robert Roebling wrote:
RR> as the subject says: what is the difference between
RR> wxTE_RICH and wxTE_RICH2 under MSW 2.4.0 ?

 From the implementation point of view, wxTE_RICH2 uses RichEdit 2.0 (or
3.0 masquerading as 2.0) while wxTE_RICH uses RichEdit 1.0 (or, you guessed
it, 3.0 masquerading as 1.0).

 From the users point of view the difference is that only wxTE_RICH2 allows
having characters in different encodings in the same control (i.e. this is
basicly why I added it: I use it in Mahogany for viewing the mail messages
which may contain text in different languages/encodings). It wasn't made
default however because RichEdit 2.0 is *very* buggy and it's almost always
better to use wxTE_RICH if you don't need the multiple languages support.

 Of course, on Win2k/Win98 and later, we don't have neither RichEdit 1.0
nor 2.0 but RichEdit 3.0 which can emulate [with some of, but not all, the
bugs present in the "real" thing] either 1.0 or 2.0. So there the
difference between wxTE_RICH and wxTE_RICH2 doesn't make much sense. But
the trouble is that I have no idea about how to distinguish RichEdit 3.0
from 1.0/2.0...

 So it's a mess. I have no idea about what we can do about it short of
writing our own richedit replacement.
```
