### PR TITLE
Fix Ctr-C and Ctr-D behavior.

### DIFF
--- a/pronsole.py
+++ b/pronsole.py
@@ -1193,6 +1193,68 @@ class pronsole(cmd.Cmd):
                 self.onecmd(a)
                 self.processing_args = False
 
+
+    # We replace this function, defined in cmd.py .
+    # It's default behavior with reagrds to Ctr-C
+    # and Ctr-D doesn't make much sense...
+
+    def cmdloop(self, intro=None):
+        """Repeatedly issue a prompt, accept input, parse an initial prefix
+        off the received input, and dispatch to action methods, passing them
+        the remainder of the line as argument.
+
+        """
+
+        self.preloop()
+        if self.use_rawinput and self.completekey:
+            try:
+                import readline
+                self.old_completer = readline.get_completer()
+                readline.set_completer(self.complete)
+                readline.parse_and_bind(self.completekey+": complete")
+            except ImportError:
+                pass
+        try:
+            if intro is not None:
+                self.intro = intro
+            if self.intro:
+                self.stdout.write(str(self.intro)+"\n")
+            stop = None
+            while not stop:
+                if self.cmdqueue:
+                    line = self.cmdqueue.pop(0)
+                else:
+                    if self.use_rawinput:
+                        try:
+                            line = raw_input(self.prompt)
+                        except EOFError:
+                            print ""
+                            self.do_exit("")
+                            exit()
+                        except KeyboardInterrupt:
+                            print ""
+                            line = ""
+                    else:
+                        self.stdout.write(self.prompt)
+                        self.stdout.flush()
+                        line = self.stdin.readline()
+                        if not len(line):
+                            line = ""
+                        else:
+                            line = line.rstrip('\r\n')
+                line = self.precmd(line)
+                stop = self.onecmd(line)
+                stop = self.postcmd(stop, line)
+            self.postloop()
+        finally:
+            if self.use_rawinput and self.completekey:
+                try:
+                    import readline
+                    readline.set_completer(self.old_completer)
+                except ImportError:
+                    pass
+
+
 if __name__ == "__main__":
 
     interp = pronsole()


### PR DESCRIPTION
We replace the cmdloop function with a slightly modified version
to achieve standard unix shell behavior on keyboard interupts and EOF.
