### PR TITLE
gcoder.py reads only the content of the file

### DIFF
--- a/gcoder.py
+++ b/gcoder.py
@@ -210,7 +210,7 @@ def main():
 		print "usage: %s filename.gcode" % sys.argv[0]
 		return
 
-	gcode = GCode(sys.argv[1])
+	gcode = GCode(list(open(sys.argv[1]))) 
 	
 	gcode.measure()
 


### PR DESCRIPTION
Previously, gcoder.py read not only the content of the file, but also it's
filename. This could have led to unexpected exceptions.
