### PR TITLE
Show connection error to the user

### DIFF
--- a/pronterface.py
+++ b/pronterface.py
@@ -1436,8 +1436,8 @@ class PronterWindow(MainWindow, pronsole.pronsole):
                 print _("You might need to add yourself to the dialout group.")
             else:
                 print e
-            # Kill the thread anyway
-            raise
+            # Kill the scope anyway
+            return
         self.statuscheck = True
         if port != self.settings.port:
             self.set("port", port)


### PR DESCRIPTION
Before, when there was an error while connecting, user didn't know, when
Pronterface wasn't launched from the terminal.

So you could just hit Connect button several times and all you've get was:

```
Connecting...
Connecting...
Connecting...
```

Now, when there is an exception during the connection, the user will notice:

```
Connecting...
Error: You are trying to connect to a non-exisiting port.
```

Or:

```
Connecting...
Error: You don't have permission to open /dev/ttyUSB0.
You might need to add yourself to the dialout group.
```

Unfortunately pyserial's SerialException doesn't provide errno yet, so the
message isn't so user friendly:

```
Connecting...
could not open port None: [Errno 2] No such file or directory: 'None'
```

I've filled a [bug report with patch to pyserial](http://sourceforge.net/tracker/?func=detail&aid=3600845&group_id=46487&atid=446302).

Together with this I've realised, there is unnecessary UTF8 decoding of the
output. When user has UTF-8 locale, there was an exception when printing the
exception to the output (almost an exception inception). So I have dropped it,
but feel free to add it back, if I broke anything else.
