### PR TITLE
Clean up echoed firmware lines, connect info.

### DIFF
--- a/pronsole.py
+++ b/pronsole.py
@@ -312,7 +312,7 @@ class pronsole(cmd.Cmd):
         return baselist+glob.glob('/dev/ttyUSB*') + glob.glob('/dev/ttyACM*') +glob.glob("/dev/tty.*")+glob.glob("/dev/cu.*")+glob.glob("/dev/rfcomm*")
 
     def online(self):
-        print "Printer is now online"
+        print "\rPrinter is now online"
         sys.stdout.write(self.promptf())
         sys.stdout.flush()
 
@@ -874,7 +874,9 @@ class pronsole(cmd.Cmd):
             self.status.update_tempreading(l)
         tstring = l.rstrip()
         if(tstring!="ok" and not tstring.startswith("ok T") and not tstring.startswith("T:") and not self.listing and not self.monitoring):
-            print tstring
+            if tstring[:5] == "echo:":
+                tstring = tstring[5:].lstrip()
+            print "\r" + tstring.ljust(15)
             sys.stdout.write(self.promptf())
             sys.stdout.flush()
         for i in self.recvlisteners:


### PR DESCRIPTION
Presently, when you connect to a printer using pronsole, one sees something like:

```
uninitialized>start
uninitialized>Printer is now online
uninitialized>echo: External Reset
printer>Marlin 1.0.0 RC2
...
```

With a few carriage returns and some string hackery, we clean up the output so that one sees:

```
No port specified - connecting to /dev/ttyACM0 at 115200bps
start
Printer is now online
External Reset
Marlin 1.0.0 RC2
```

Much cleaner!
