### PR TITLE
Gcoder support M82/M83 for relative E to give correct filament length

### DIFF
--- a/gcoder.py
+++ b/gcoder.py
@@ -29,6 +29,7 @@ class Line(object):
 		self.raw = l.upper().lstrip()
 		self.imperial = False
 		self.relative = False
+		self.relative_e = False
 		
 		if ";" in self.raw:
 			self.raw = self.raw.split(";")[0]
@@ -110,6 +111,7 @@ class GCode(object):
 		#checks for G20, G21, G90 and G91, sets imperial and relative flags
 		imperial = False
 		relative = False
+		relative_e = False
 		for line in self.lines:
 			if line.command() == "G20":
 				imperial = True
@@ -117,11 +119,18 @@ class GCode(object):
 				imperial = False
 			elif line.command() == "G90":
 				relative = False
+				relative_e = False
 			elif line.command() == "G91":
 				relative = True
+				relative_e = True
+			elif line.command() == "M82":
+				relative_e = False
+			elif line.command() == "M83":
+				relative_e = True
 			elif line.is_move():
 				line.imperial = imperial
 				line.relative = relative
+				line.relative_e = relative_e
 				
 
 	def measure(self):
@@ -196,7 +205,7 @@ class GCode(object):
 					total_e += cur_e
 					cur_e = line.e
 			elif line.is_move() and line.e:
-				if line.relative:
+				if line.relative_e:
 					cur_e += line.e
 				else:
 					cur_e = line.e


### PR DESCRIPTION
Slicer allows E to be relative while other coordinates are absolute, using M82/M83 gcode to set whether the extrusion axis is absolute or relative.

See http://reprap.org/wiki/G-code#M83:_set_extruder_to_relative_mode

This patch allows the filament length to be calculated appropriately.
