### PR TITLE
Use "/usr/bin/env python2" for all shebangs

### DIFF
--- a/gcoder.py
+++ b/gcoder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # This file is copied from GCoder.
 #
 # GCoder is free software: you can redistribute it and/or modify

--- a/plater.py
+++ b/plater.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # This file is part of the Printrun suite.
 #

--- a/printcore.py
+++ b/printcore.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # This file is part of the Printrun suite.
 #

--- a/printrun/SkeinforgeQuickEditDialog.py
+++ b/printrun/SkeinforgeQuickEditDialog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # This file is part of the Printrun suite.
 #
 # Printrun is free software: you can redistribute it and/or modify

--- a/printrun/calibrateextruder.py
+++ b/printrun/calibrateextruder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # This file is part of the Printrun suite.
 #
 # Printrun is free software: you can redistribute it and/or modify

--- a/printrun/gcview.py
+++ b/printrun/gcview.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # This file is part of the Printrun suite.
 #
 # Printrun is free software: you can redistribute it and/or modify

--- a/printrun/graph.py
+++ b/printrun/graph.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 # This file is part of the Printrun suite.
 #

--- a/printrun/stlview.py
+++ b/printrun/stlview.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 # This file is part of the Printrun suite.
 #

--- a/printrun/webinterface.py
+++ b/printrun/webinterface.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # This file is part of the Printrun suite.
 #
 # Printrun is free software: you can redistribute it and/or modify

--- a/pronsole.py
+++ b/pronsole.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # This file is part of the Printrun suite.
 #

--- a/pronterface.py
+++ b/pronterface.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # This file is part of the Printrun suite.
 #

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # This file is part of the Printrun suite.
 #


### PR DESCRIPTION
This fixes https://github.com/kliment/Printrun/issues/325

If ever this patch no longer cleanly applies, or you wish to apply it to experimental, it can be reproduced with the command:

```
grep -rl '^#!' * | xargs sed -i 's|#!.*|#!/usr/bin/env python2|'
```
