### PR TITLE
[printcore] Have print_thread rejoin execution thread.

### DIFF
--- a/printcore.py
+++ b/printcore.py
@@ -289,6 +289,8 @@ class printcore():
         self.sentlines = {}
         self.log = []
         self.sent = []
+        self.print_thread.join()
+        self.print_thread = None
         if self.endcb:
             #callback for printing done
             try: self.endcb()


### PR DESCRIPTION
This modification has the print thread rejoin the main execution thread once the print has completed.
