### PR TITLE
Dynamically resize temperature graph

### DIFF
--- a/printrun/graph.py
+++ b/printrun/graph.py
@@ -57,7 +57,6 @@ class Graph(BufferedCanvas):
         gc = wx.GraphicsContext.Create(dc)
 
     def updateTemperatures(self, event):
-	#print "ypos(%f)=%d"%(self.extruder0temps[-1],self._y_pos(self.extruder0temps[-1]))
         self.AddBedTemperature(self.bedtemps[-1])
         self.AddBedTargetTemperature(self.bedtargettemps[-1])
         self.AddExtruder0Temperature(self.extruder0temps[-1])


### PR DESCRIPTION
I've been working on some updates to the temperature graph. Besides some minor display fixes, I've set it to rescale based on the range of temperatures in the history. This makes it much easier to see small changes in temperature, especially if you don't have a heated bed to display on the graph.

**Specific changes:**
- Added a new helper class, Graph._YBounds, which is responsible for managing the y scale.
  - Maximum zoom of 5C (_YBounds.minimum_scale)
  - Rescales every 10s to prevent unnecessary jitter (_YBounds.update_freq), unless a rescale is needed more often to keep the full temp on the graph
  - 10% buffer to allow the temperature to change without requiring a rescale (_YBounds.buffer)
- Always shows the full history for ext0. Also shows the bed and ext1 if they are active (>5 degrees or target>0).
- Show scale bars on right and bottom of the graph when appropriate
- Show ext1 for dualstrusion, but only consider it for scaling if attached (not well tested)

I've been testing it on Mac and linux with no problems. In the resizing_graph branch it is always enabled, but I could also add a cli parameter (or change Graph.rescale_y) to switch between the 0-250 scale and the dynamic scale, if anyone prefers the old behavior.
