### PR TITLE
Changed extrusion length to hidden setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 uploads
 .DS_Store
 .vagrant
+prontserve-env

--- a/printrun/gui.py
+++ b/printrun/gui.py
@@ -170,9 +170,11 @@ def add_extra_controls(self, root, parentpanel, extra_buttons = None):
 
     esettingspanel = root.newPanel(parentpanel)
     esettingssizer = wx.BoxSizer(wx.HORIZONTAL)
-    root.edist = wx.SpinCtrl(esettingspanel, -1, str(root.settings.extrusion_default), min = 0, max = 1000, size = (70, -1))
+    root.edist = wx.SpinCtrl(esettingspanel, -1, str(root.settings.last_extrusion), min = 0, max = 1000, size = (70, -1))
     root.edist.SetBackgroundColour((225, 200, 200))
     root.edist.SetForegroundColour("black")
+    root.edist.Bind(wx.EVT_SPINCTRL, root.setfeeds)
+    root.edist.Bind(wx.EVT_TEXT, root.setfeeds)
     esettingssizer.Add(root.edist, flag = wx.ALIGN_CENTER | wx.RIGHT, border = 5)
     esettingssizer.Add(wx.StaticText(esettingspanel, -1, _("mm @")), flag = wx.ALIGN_CENTER | wx.RIGHT, border = 5)
     root.edist.SetToolTip(wx.ToolTip("Amount to Extrude or Retract (mm)"))

--- a/pronsole.py
+++ b/pronsole.py
@@ -244,7 +244,6 @@ class Settings(object):
         self._add(SpinSetting("xy_feedrate", 3000, 0, 50000, _("X && Y manual feedrate"), _("Feedrate for Control Panel Moves in X and Y (mm/min)"), "Printer"))
         self._add(SpinSetting("z_feedrate", 200, 0, 50000, _("Z manual feedrate"), _("Feedrate for Control Panel Moves in Z (mm/min)"), "Printer"))
         self._add(SpinSetting("e_feedrate", 100, 0, 1000, _("E manual feedrate"), _("Feedrate for Control Panel Moves in Extrusions (mm/min)"), "Printer"))
-        self._add(SpinSetting("extrusion_default", 5, 0, 1000, _("Extrusion length"), _("Extrusion/REtraction (mm)"), "Printer"))
         self._add(StringSetting("slicecommand", "python skeinforge/skeinforge_application/skeinforge_utilities/skeinforge_craft.py $s", _("Slice command"), _("Slice command"), "External"))
         self._add(StringSetting("sliceoptscommand", "python skeinforge/skeinforge_application/skeinforge.py", _("Slicer options command"), _("Slice settings command"), "External"))
         self._add(StringSetting("final_command", "", _("Final command"), _("Executable to run when the print is finished"), "External"))
@@ -264,6 +263,8 @@ class Settings(object):
         self._add(HiddenSetting("project_prelift_gcode", ""))
         self._add(HiddenSetting("project_postlift_gcode", ""))
         self._add(HiddenSetting("pause_between_prints", True))
+        self._add(HiddenSetting("default_extrusion", 5.0))
+        self._add(HiddenSetting("last_extrusion", 5.0))
 
     _settings = []
 
@@ -1236,7 +1237,7 @@ class pronsole(cmd.Cmd):
             return []
 
     def do_extrude(self, l, override = None, overridefeed = 300):
-        length = 5  # default extrusion length
+        length = self.settings.default_extrusion  # default extrusion length
         feed = self.settings.e_feedrate  # default speed
         if not self.p.online:
             self.logError("Printer is not online. Unable to extrude.")
@@ -1276,7 +1277,7 @@ class pronsole(cmd.Cmd):
         self.log(_("extrude 10 210 - extrudes 10mm of filament at 210mm/min (3.5mm/s)"))
 
     def do_reverse(self, l):
-        length = 5  # default extrusion length
+        length = self.settings.default_extrusion  # default extrusion length
         feed = self.settings.e_feedrate  # default speed
         if not self.p.online:
             self.logError(_("Printer is not online. Unable to reverse."))

--- a/pronterface.desktop
+++ b/pronterface.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Name=Pronterface
+Comment=Pronterface
+Icon=/usr/share/pixmaps/P-face.ico
+Exec=/usr/bin/python2 /usr/bin/pronterface.py
+Path=/usr/share/pronterface/
+StartupNotify=true
+Terminal=false
+Categories=GNOME;GTK;Utility;

--- a/pronterface.py
+++ b/pronterface.py
@@ -212,6 +212,8 @@ class PronterWindow(MainWindow, pronsole.pronsole):
         self.settings._add(HiddenSetting("last_bed_temperature", 0.0))
         self.settings._add(HiddenSetting("last_file_path", ""))
         self.settings._add(HiddenSetting("last_temperature", 0.0))
+        self.settings._add(HiddenSetting("last_extrusion", 5.0))
+        self.settings._add(HiddenSetting("default_extrusion", 5.0))
         self.settings._add(FloatSpinSetting("preview_extrusion_width", 0.5, 0, 10, _("Preview extrusion width"), _("Width of Extrusion in Preview"), "UI"), self.update_gviz_params)
         self.settings._add(SpinSetting("preview_grid_step1", 10., 0, 200, _("Fine grid spacing"), _("Fine Grid Spacing"), "UI"), self.update_gviz_params)
         self.settings._add(SpinSetting("preview_grid_step2", 50., 0, 200, _("Coarse grid spacing"), _("Coarse Grid Spacing"), "UI"), self.update_gviz_params)
@@ -902,6 +904,10 @@ class PronterWindow(MainWindow, pronsole.pronsole):
             self.settings._set("xy_feedrate", self.xyfeedc.GetValue())
         except:
             pass
+        try:
+            self.settings._set("last_extrusion", self.edist.GetValue())
+        except:
+            pass
 
     def cbuttons_reload(self):
         allcbs = getattr(self, "custombuttonbuttons", [])
@@ -1275,6 +1281,8 @@ class PronterWindow(MainWindow, pronsole.pronsole):
             self.save_in_rc("set xy_feedrate", "set xy_feedrate %d" % self.settings.xy_feedrate)
             self.save_in_rc("set z_feedrate", "set z_feedrate %d" % self.settings.z_feedrate)
             self.save_in_rc("set e_feedrate", "set e_feedrate %d" % self.settings.e_feedrate)
+        if self.settings.last_extrusion != self.settings.default_extrusion:
+            self.save_in_rc("set last_extrusion", "set last_extrusion %d" % self.settings.last_extrusion)
         if self.excluder:
             self.excluder.close_window()
         wx.CallAfter(self.gwindow.Destroy)

--- a/prontserve.py
+++ b/prontserve.py
@@ -189,6 +189,9 @@ class Prontserve(pronsole.pronsole, EventEmitter):
   def post_process_print_job(self, filename, filebody):
     return FastGCode(filebody.split("\n"))
 
+  def get_print_job_memory_footprint(self, filename,filebody):
+    return 0 # TODO
+
   def current_print_line(self):
     if(self.p.printing): return (self.p.queueindex)
     return 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,10 @@
-inflection
-pybonjour
 git+https://github.com/D1plo1d/tornado.git
 git+https://github.com/D1plo1d/py-mdns.git
 git+https://github.com/construct-protocol/construct_server.py
+
+inflection>=0.2.0
+mdns>=1.0.0
+objgraph>=1.7.2
+pybonjour>=1.1.1
+pyserial==2.6
+wsgiref==0.1.2

--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,8 @@ if sys.argv[1] in("install", "uninstall") and len(prefix):
     sys.argv += ["--prefix", prefix]
 
 target_images_path = "share/pronterface/images/"
-data_files = [('share/pixmaps/', ['P-face.ico', 'plater.ico', 'pronsole.ico'])]
+data_files = [('share/pixmaps/', ['P-face.ico', 'plater.ico', 'pronsole.ico']),
+              ('share/applications', ['pronterface.desktop'])]
 
 for basedir, subdirs, files in os.walk("images"):
     images = []
@@ -156,7 +157,7 @@ setup(name = "Printrun",
       url = "http://github.com/kliment/Printrun/",
       license = "GPLv3",
       data_files = data_files,
-      packages = ["printrun", "printrun.cairosvg", "printrun.server", "printrun.gl", "printrun.gl.libtatlin"],
+      packages = ["printrun", "printrun.cairosvg", "printrun.gl", "printrun.gl.libtatlin"],
       scripts = ["pronsole.py", "pronterface.py", "plater.py", "printcore.py", "prontserve.py"],
       cmdclass = cmdclass,
       ext_modules = extensions,


### PR DESCRIPTION
Pulled latest master from kliment/printun and changed extrusion length
to a hidden setting. It is now saved upon change as
settings.last_extrusion and can be set as such. Also added default
extrusion length that may be used as a fall back for deploying printrun
with a different default extrusion length without having to change that
everywhere in the code.
