### PR TITLE
Plater: Display a decent error message when loading a file fails

### DIFF
--- a/printrun/plater.py
+++ b/printrun/plater.py
@@ -235,9 +235,17 @@ class StlPlater(Plater):
 
     def load_file(self, filename):
         if filename.lower().endswith(".stl"):
-            self.load_stl(filename)
+            try:
+                self.load_stl(filename)
+            except:
+                dlg = wx.MessageDialog(self, _("Loading STL file failed"), _("Error"),wx.OK)
+                dlg.ShowModal()
         elif filename.lower().endswith(".scad"):
-            self.load_scad(filename)
+            try:
+                self.load_scad(filename)
+            except:
+                dlg = wx.MessageDialog(self, _("Loading OpenSCAD file failed"), _("Error"),wx.OK)
+                dlg.ShowModal()
 
     def load_scad(self, name):
         lf = open(name)


### PR DESCRIPTION
In plater, when loading a corrupted STL file, it displays traceback in terminal but says nothing. This makes sure that it will display an actuall GUI error message to the user.

Also added it to the SCAD load option.
