### PR TITLE
Lasercutting: Relative moves with the jog dial should move with G0 instead of G1

### DIFF
--- a/printrun/pronsole.py
+++ b/printrun/pronsole.py
@@ -1690,7 +1690,7 @@ class pronsole(cmd.Cmd):
         except:
             pass
         self.p.send_now("G91")
-        self.p.send_now("G1 " + axis + str(l[1]) + " F" + str(feed))
+        self.p.send_now("G0 " + axis + str(l[1]) + " F" + str(feed))
         self.p.send_now("G90")
 
     def help_move(self):


### PR DESCRIPTION
In preparation for Tim Schmidt's Marlin upgrade for laser cutters and selective laser sintering, G0 should be move with laser off, G1 move with laser on. Thus, Printrun's default of G1 relative moves when the job buttons are depressed need to be changed to G0, so that the laser does not fire when moving the toolhead around.

More on Tim's firmware is available here:
https://github.com/lansing-makers-network/buildlog-lasercutter-marlin

This combination of Tim's firmware and this version of Printrun have been verified on MillerLab selective laser sintering OpenSLS machine.
