### PR TITLE
Fix reversed Z and Y homing buttons.

### DIFF
--- a/printrun/gui/xybuttons.py
+++ b/printrun/gui/xybuttons.py
@@ -46,8 +46,8 @@ class XYButtons(BufferedCanvas):
     corner_to_axis = {
         -1: "xy",
         0: "x",
-        1: "z",
-        2: "y",
+        1: "y",
+        2: "z",
         3: "all",
     }
 


### PR DESCRIPTION
It seemed that the Z and Y homing buttons were reversed. This should now be fixed.
