### PR TITLE
FIX: Unable to connect on Debian testing

### DIFF
--- a/printrun/printcore.py
+++ b/printrun/printcore.py
@@ -17,7 +17,7 @@
 
 __version__ = "2014.08.01"
 
-from serial import Serial, SerialException
+from serial import Serial, SerialException, PARITY_ODD, PARITY_NONE
 from select import error as SelectError
 from threading import Thread, Lock
 from Queue import Queue, Empty as QueueEmpty
@@ -189,7 +189,11 @@ class printcore():
                 try:
                     self.printer = Serial(port = self.port,
                                           baudrate = self.baud,
-                                          timeout = 0.25)
+                                          timeout = 0.25,
+                                          parity = PARITY_ODD)
+                    self.printer.close()
+                    self.printer.parity = PARITY_NONE
+                    self.printer.open()
                 except SerialException as e:
                     self.logError(_("Could not connect to %s at baudrate %s:") % (self.port, self.baud) +
                                   "\n" + _("Serial error: %s") % e)


### PR DESCRIPTION
I only was able to connect with printrun after connect/disconnect using Repetier or Arduino.

After a successfull connection with Printrun, if I disconnect i was unable to connect again. This trick allows to connect and disconnect from Printrun without problems.

I'm using:
Debian testing
Linux acer 3.14-2-686-pae #1 SMP Debian 3.14.15-2 (2014-08-09) i686 GNU/Linux
Python 2.7.8
pyserial 2.6
