### PR TITLE
add flow control

### DIFF
--- a/printrun/gui/controls.py
+++ b/printrun/gui/controls.py
@@ -41,9 +41,9 @@ def add_extra_controls(self, root, parentpanel, extra_buttons = None, mini_mode 
     if standalone_mode:
         gauges_base_line = base_line + 10
     elif mini_mode and root.display_graph:
-        gauges_base_line = base_line + 6
+        gauges_base_line = base_line + 7
     else:
-        gauges_base_line = base_line + 5
+        gauges_base_line = base_line + 6
     tempdisp_line = gauges_base_line + (2 if root.display_gauges else 0)
     if mini_mode and root.display_graph:
         e_base_line = base_line + 3
@@ -62,6 +62,7 @@ def add_extra_controls(self, root, parentpanel, extra_buttons = None, mini_mode 
         "ebuttons": (e_base_line + 0, 0),
         "esettings": (e_base_line + 1, 0),
         "speedcontrol": (e_base_line + 2, 0),
+        "flowcontrol": (e_base_line + 3, 0),
         "htemp_gauge": (gauges_base_line + 0, 0),
         "btemp_gauge": (gauges_base_line + 1, 0),
         "tempdisp": (tempdisp_line, 0),
@@ -81,6 +82,7 @@ def add_extra_controls(self, root, parentpanel, extra_buttons = None, mini_mode 
         "ebuttons": (1, 5 if root.display_graph else 6),
         "esettings": (1, 5 if root.display_graph else 6),
         "speedcontrol": (1, 5 if root.display_graph else 6),
+        "flowcontrol": (1, 5 if root.display_graph else 6),
         "htemp_gauge": (1, 5 if mini_mode else 6),
         "btemp_gauge": (1, 5 if mini_mode else 6),
         "tempdisp": (1, 5 if mini_mode else 6),
@@ -217,6 +219,40 @@ def add_extra_controls(self, root, parentpanel, extra_buttons = None, mini_mode 
         root.speed_setbtn.SetBackgroundColour("red")
         root.speed_spin.SetValue(value)
     root.speed_slider.Bind(wx.EVT_SCROLL, speedslider_scroll)
+
+    # Flow control #
+    flowpanel = root.newPanel(parentpanel)
+    flowsizer = wx.BoxSizer(wx.HORIZONTAL)
+    flowsizer.Add(wx.StaticText(flowpanel, -1, _("Print flow:")), flag = wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
+
+    root.flow_slider = wx.Slider(flowpanel, -1, 100, 1, 300)
+    flowsizer.Add(root.flow_slider, 1, flag = wx.EXPAND)
+
+    root.flow_spin = FloatSpin(flowpanel, -1, value = 100, min_val = 1, max_val = 300, digits = 0, style = wx.ALIGN_LEFT, size = (60, -1))
+    flowsizer.Add(root.flow_spin, 0, flag = wx.ALIGN_CENTER_VERTICAL)
+    root.flow_label = wx.StaticText(flowpanel, -1, _("%"))
+    flowsizer.Add(root.flow_label, flag = wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
+
+    def flowslider_set(event):
+        root.do_setflow()
+        root.flow_setbtn.SetBackgroundColour(wx.NullColour)
+    root.flow_setbtn = make_button(flowpanel, _("Set"), flowslider_set, _("Set print flow factor"), size = (38, -1), style = wx.BU_EXACTFIT)
+    root.printerControls.append(root.flow_setbtn)
+    flowsizer.Add(root.flow_setbtn, flag = wx.ALIGN_CENTER)
+    flowpanel.SetSizer(flowsizer)
+    add("flowcontrol", flowpanel, flag = wx.EXPAND)
+
+    def flowslider_spin(event):
+        value = root.flow_spin.GetValue()
+        root.flow_setbtn.SetBackgroundColour("red")
+        root.flow_slider.SetValue(value)
+    root.flow_spin.Bind(wx.EVT_SPINCTRL, flowslider_spin)
+
+    def flowslider_scroll(event):
+        value = root.flow_slider.GetValue()
+        root.flow_setbtn.SetBackgroundColour("red")
+        root.flow_spin.SetValue(value)
+    root.flow_slider.Bind(wx.EVT_SCROLL, flowslider_scroll)
 
     # Temperature gauges #
 

--- a/printrun/pronterface.py
+++ b/printrun/pronterface.py
@@ -438,6 +438,21 @@ class PronterWindow(MainWindow, pronsole.pronsole):
         except Exception, x:
             self.logError(_("You must enter a speed. (%s)") % (repr(x),))
 
+    def do_setflow(self, l = ""):
+        try:
+            if l.__class__ not in (str, unicode) or not len(l):
+                l = str(self.flow_slider.GetValue())
+            else:
+                l = l.lower()
+            flow = int(l)
+            if self.p.online:
+                self.p.send_now("M221 S" + l)
+                self.log(_("Setting print flow factor to %d%%.") % flow)
+            else:
+                self.logError(_("Printer is not online."))
+        except Exception, x:
+            self.logError(_("You must enter a flow. (%s)") % (repr(x),))
+
     def setbedgui(self, f):
         self.bsetpoint = f
         if self.display_gauges: self.bedtgauge.SetTarget(int(f))


### PR DESCRIPTION
This patch adds a second slider for flow control, which sends M221 Sxxx

RepRapWiki documents M221 availabbility on Sprinter, Marlin, Repetier and Smoothie:
http://reprap.org/wiki/G-code#M221:_Set_extrude_factor_override_percentage

The idea originated from RepetierHost, where I used it a lot some years ago with Marlin firmware.
From my experience this is a very useful interactive tweak while printing.

I have added this about 8 month ago and tested since then with my smoothieboard.
It's a simple copy of the "print speed" slider with appropriate changes.
