### PR TITLE
setup typo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,7 +125,7 @@ if sys.argv[1] in("install", "uninstall") and len(prefix):
     sys.argv += ["--prefix", prefix]
 
 target_images_path = "share/pronterface/images/"
-data_files = [('share/pixmaps/', ['pronterface.png', 'plater.png', 'pronsole.png']),
+data_files = [('share/pixmaps', ['pronterface.png', 'plater.png', 'pronsole.png']),
               ('share/applications', ['pronterface.desktop', 'pronsole.desktop', 'plater.desktop']),
               ('share/appdata', ['pronterface.appdata.xml', 'pronsole.appdata.xml', 'plater.appdata.xml'])]
 


### PR DESCRIPTION
Fix this error

```
running install_data
Traceback (most recent call last):
 File "setup.py", line 171, in <module>
   ext_modules = extensions,
 File "C:\Python27\lib\distutils\core.py", line 152, in setup
   dist.run_commands()
 File "C:\Python27\lib\distutils\dist.py", line 953, in run_commands
   self.run_command(cmd)
 File "C:\Python27\lib\distutils\dist.py", line 972, in run_command
   cmd_obj.run()
 File "setup.py", line 43, in run
   _install.run(self)
 File "C:\Python27\lib\distutils\command\install.py", line 575, in run
   self.run_command(cmd_name)
 File "C:\Python27\lib\distutils\cmd.py", line 326, in run_command
   self.distribution.run_command(command)
 File "C:\Python27\lib\distutils\dist.py", line 972, in run_command
   cmd_obj.run()
 File "setup.py", line 71, in run
   _install_data.run(self)
 File "C:\Python27\lib\distutils\command\install_data.py", line 58, in run
   dir = convert_path(f[0])
 File "C:\Python27\lib\distutils\util.py", line 201, in convert_path
   raise ValueError, "path '%s' cannot end with '/'" % pathname
ValueError: path 'share/pixmaps/' cannot end with '/'
```