### PR TITLE
Add a wrapper around pySerial to monkey patch support for custom baudrates

### DIFF
--- a/printrun/printcore.py
+++ b/printrun/printcore.py
@@ -17,7 +17,7 @@
 
 __version__ = "2015.03.10"
 
-from serial import Serial, SerialException, PARITY_ODD, PARITY_NONE
+from serialWrapper import Serial, SerialException, PARITY_ODD, PARITY_NONE
 from select import error as SelectError
 import threading
 from Queue import Queue, Empty as QueueEmpty

--- a/printrun/serialWrapper.py
+++ b/printrun/serialWrapper.py
@@ -10,7 +10,14 @@ import sys
 if sys.platform.startswith('linux'):
 	import serial.serialposix
 
-	if not hasattr(serial.serialposix, "TCGETS2") and \
+	try:
+		import pkg_resources
+
+		old_version = float(pkg_resources.get_distribution("pyserial").version) < 2.7
+	except:
+		old_version = True
+
+	if old_version and not hasattr(serial.serialposix, "TCGETS2") and \
 	   hasattr(serial.serialposix, "set_special_baudrate"):
 		# Detected pyserial < 2.7 which doesn't support custom baudrates
 		# Replacing set_special_baudrate with updated function from pyserial 2.7

--- a/printrun/serialWrapper.py
+++ b/printrun/serialWrapper.py
@@ -5,9 +5,9 @@
 # Therefore, it follows the license used by pyserial which is the '3-clause BSD license'
 
 from serial import *
-import os
+import sys
 
-if os.name == 'posix':
+if sys.platform.startswith('linux'):
 	import serial.serialposix
 
 	if not hasattr(serial.serialposix, "TCGETS2") and \

--- a/printrun/serialWrapper.py
+++ b/printrun/serialWrapper.py
@@ -1,7 +1,8 @@
 # Serial wrapper around pyserial that adds support for custom baudrates (250000)
 # on linux, when pyserial is < 2.7
 
-__copyright__ = "Copyright (C) 2015 Aleph Objects - Released under terms of the AGPLv3 License"
+# This code was copied from the pyserial 2.7 base code.
+# Therefore, it follows the license used by pyserial which is the '3-clause BSD license'
 
 from serial import *
 import os

--- a/printrun/serialWrapper.py
+++ b/printrun/serialWrapper.py
@@ -1,0 +1,41 @@
+# Serial wrapper around pyserial that adds support for custom baudrates (250000)
+# on linux, when pyserial is < 2.7
+
+__copyright__ = "Copyright (C) 2015 Aleph Objects - Released under terms of the AGPLv3 License"
+
+from serial import *
+import os
+
+if os.name == 'posix':
+	import serial.serialposix
+
+	if not hasattr(serial.serialposix, "TCGETS2") and \
+	   hasattr(serial.serialposix, "set_special_baudrate"):
+		# Detected pyserial < 2.7 which doesn't support custom baudrates
+		# Replacing set_special_baudrate with updated function from pyserial 2.7
+
+		TCGETS2 = 0x802C542A
+		TCSETS2 = 0x402C542B
+		BOTHER = 0o010000
+
+		def set_special_baudrate(port, baudrate):
+			# right size is 44 on x86_64, allow for some growth
+			import array
+			buf = array.array('i', [0] * 64)
+
+			try:
+				# get serial_struct
+				FCNTL.ioctl(port.fd, TCGETS2, buf)
+				# set custom speed
+				buf[2] &= ~TERMIOS.CBAUD
+				buf[2] |= BOTHER
+				buf[9] = buf[10] = baudrate
+
+				# set serial_struct
+				res = FCNTL.ioctl(port.fd, TCSETS2, buf)
+			except IOError, e:
+				raise ValueError('Failed to set custom baud rate (%s): %s' % (baudrate, e))
+
+		# We need to change the function inside the serialposix module otherwise, it won't
+		# be called by the code within that module
+		serial.serialposix.set_special_baudrate = set_special_baudrate


### PR DESCRIPTION
This is only useful if the pyserial version installed is lower than 2.7 since that doesn't support custom baudrates on linux.

The monkey patch will replace the set_special_baudrates function in the serial module with the version of the function from pyserial 2.7 which allows the use of 250000 baudrates on Linux. If pyserial is 2.7 or newer, it won't do anything.