### PR TITLE
Restore command line arguments pass-thru.

### DIFF
--- a/pronterface.py
+++ b/pronterface.py
@@ -40,10 +40,13 @@ if __name__ == '__main__':
             "  pronterface [OPTION]\n\n"+\
             "Options:\n"+\
             "  -V, --version\t\t\tPrint program's version number and exit\n"+\
-            "  -h, --help\t\t\tPrint this help message and exit\n"
+            "  -h, --help\t\t\tPrint this help message and exit\n"+\
+            "  -a, --autoconnect\t\t\tautomatically try to connect to printer on startup\n"+\
+            "  -c, --conf\t\t\tload this file on startup instead of .pronsolerc ; you may chain config files, if so settings auto-save will use the last specified file\n"+\
+            "  -e, --execute\t\t\texecutes command after configuration/.pronsolerc is loaded ; macros/settings from these commands are not autosaved"
 
     try:
-        opts, args = getopt.getopt(sys.argv[1:], "hV", ["help", "version"])
+        opts, args = getopt.getopt(sys.argv[1:], "hVcea", ["help", "version", "conf", "execute", "autoconnect"])
     except getopt.GetoptError, err:
         print str(err)
         print usage


### PR DESCRIPTION
Commit 3ef393e94c3516ade8e20c539441c274649f538f added in -v/-h command line arguments into the main pronterface.py, and then via boilerplate exception on the getopt stuff, caused the rest of the possible command line arguments not to get passed through to the printrun/pronterface.py and printrun/pronsole.py modules. This fixes that.

I missed having the ability to have different config files for each of my printers. 