### PR TITLE
p/pronsole: Improve tracebacks for custom config

### DIFF
--- a/printrun/pronsole.py
+++ b/printrun/pronsole.py
@@ -688,7 +688,12 @@ class pronsole(cmd.Cmd):
             logger = logging.getLogger()
             logger.setLevel(logging.DEBUG)
         for config in args.conf:
-            self.load_rc(config)
+            try:
+                self.load_rc(config)
+            except EnvironmentError as err:
+                print ("ERROR: Unable to load configuration file: %s" %
+                       str(err)[10:])
+                sys.exit(1)
         if not self.rc_loaded:
             self.load_default_rc()
         self.processing_args = True


### PR DESCRIPTION
Currently, failing to load a config file gives the following traceback:
```
$ ./pronterface.py -c nonexistent
WARNING:root:Memory-efficient GCoder implementation unavailable: No module named gcoder_line
Traceback (most recent call last):
  File "./pronterface.py", line 62, in <module>
    app = PronterApp(False)
  File "//Printrun/printrun/pronterface.py", line 2222, in __init__
    self.mainwindow = PronterWindow(self)
  File "//Printrun/printrun/pronterface.py", line 173, in __init__
    self.parse_cmdline(sys.argv[1:])
  File "//Printrun/printrun/pronsole.py", line 711, in parse_cmdline
    self.process_cmdline_arguments(args)
  File "//Printrun/printrun/pronterface.py", line 900, in process_cmdline_arguments
    pronsole.pronsole.process_cmdline_arguments(self, args)
  File "//Printrun/printrun/pronsole.py", line 691, in process_cmdline_arguments
    self.load_rc(config)
  File "//Printrun/printrun/pronsole.py", line 581, in load_rc
    rc = codecs.open(rc_filename, "r", "utf-8")
  File "/usr/lib/python2.7/codecs.py", line 896, in open
    file = __builtin__.open(filename, mode, buffering)
IOError: [Errno 2] No such file or directory: 'nonexistent'
```
Which seems too long and messy to me, being pretty simple to boil down the information given to the user.

While digging into this, I noticed that when it fails to load the given configuration file it aborts the program. Should it load the default configuration file and raise a warning instead?

If you feel something is not in line with the coding style please let me know, I will gladly change it.