### PR TITLE
Compatibility with Slic3r 1.3.0

### DIFF
--- a/printrun/pronterface.py
+++ b/printrun/pronterface.py
@@ -2222,6 +2222,9 @@ Printrun. If not, see <http://www.gnu.org/licenses/>."""
     def set_slic3r_config(self, configfile, cat, file):
         """Set new preset for a given category"""
         self.slic3r_configs[cat] = file
+        # Starting from Slic3r 1.3.0, preset names have no extension
+        if not os.path.isfile(self.slic3r_configs[cat]) and os.path.isfile(self.slic3r_configs[cat] + ".ini")
+            self.slic3r_configs[cat] += ".ini"
         if self.settings.slic3rupdate:
             config = self.read_slic3r_config(configfile)
             config.set("presets", cat, os.path.basename(file))


### PR DESCRIPTION
Slic3r 1.3.0 saves preset names without extension. This change should make Pronterface compatible with the new behavior. I can't test the change at the moment, so I'm parking it in a PR. :)

https://github.com/alexrj/Slic3r/issues/3813