### PR TITLE
Fix AppStream files' metadata and location

### DIFF
--- a/plater.appdata.xml
+++ b/plater.appdata.xml
@@ -1,14 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<application>
- <id type="desktop">plater.desktop</id>
- <licence>CC0</licence>
+<component type="desktop-application">
+ <id>plater</id>
+ <metadata_license>FSFAP</metadata_license>
+ <project-license>GPL-3.0+</project-license>
+ <name>Plater</name>
  <summary>3D printer plating tool</summary>
  <description>
   <p>Plater is a simple graphical tool for preparing plates for desktop 3D printers, such as RepRap.</p>
-  <p>It lets you load 3D models and manipulate them on XY plane. It is also possible to let Plater automatically arrange the files to fit. You can than export the prepared plate for later use or load it directly to Pronterface (if installed).</p>
+  <p>It lets you load 3D models and manipulate them on XY plane. It is also possible to let Plater automatically arrange the files to fit. You can then export the prepared plate for later use or load it directly to Pronterface (if installed).</p>
  </description>
+ <launchable type="desktop-id">plater.desktop</launchable>
  <screenshots>
   <screenshot type="default" width="804" height="606">https://raw.github.com/kliment/Printrun/master/screenshots/plater.png</screenshot>
  </screenshots>
  <url type="homepage">https://github.com/kliment/Printrun</url>
-</application>
+</component>

--- a/pronsole.appdata.xml
+++ b/pronsole.appdata.xml
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<application>
- <id type="desktop">pronsole.desktop</id>
- <licence>CC0</licence>
+<component type="desktop-application">
+ <id>pronsole</id>
+ <metadata_license>FSFAP</metadata_license>
+ <project-license>GPL-3.0+</project-license>
+ <name>Pronsole</name>
  <summary>3D printer host software for console</summary>
  <description>
-  <p>Pronsole is a command line user interface for desktop 3D printers, such as RepRap. It lets you to load Gcode, connect to printer and send the Gcode to it. Best option for controling 3D printer from headless or not enough powerful machines.</p>
+  <p>Pronsole is a command line user interface for desktop 3D printers, such as RepRap. It lets you to load Gcode, connect to printer and send the Gcode to it. Best option for controlling 3D printer from headless or not enough powerful machines.</p>
   <p>It allows you not only to send Gcode form file, but also control the printer manually or send Gcode commands directly to the printer.</p>
-  <p>Is integrates slicing tool, so if you load an STL 3D model to it as well as Gcode.</p>
+  <p>It integrates with slicing tools, so if you load an STL 3D model to it,it will slice and load it automatically.</p>
  </description>
+ <launchable type="desktop-id">pronsole.desktop</launchable>
  <screenshots>
   <screenshot type="default" width="659" height="388">https://raw.github.com/kliment/Printrun/master/screenshots/pronsole.png</screenshot>
  </screenshots>
  <url type="homepage">https://github.com/kliment/Printrun</url>
-</application>
+</component>

--- a/pronterface.appdata.xml
+++ b/pronterface.appdata.xml
@@ -1,16 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<application>
- <id type="desktop">pronterface.desktop</id>
- <licence>CC0</licence>
+<component type="desktop-application">
+ <id>pronterface</id>
+ <metadata_license>FSFAP</metadata_license>
+ <project-license>GPL-3.0+</project-license>
+ <name>Pronterface</name>
  <summary>3D printer host software</summary>
  <description>
   <p>Pronterface is a graphical user interface for desktop 3D printers, such as RepRap. It lets you view Gcode, connect to printer and send the Gcode to it. It's feature rich yet minimalist application.</p>
   <p>It allows you not only to send Gcode form file, but also control the printer manually or send Gcode commands directly trough input field.</p>
-  <p>Is integrates slicing tool, so if you load an STL 3D model to it, it will slice and load it automatically.</p>
+  <p>It integrates with slicing tools, so if you load an STL 3D model to it, it will slice and load it automatically.</p>
  </description>
+ <launchable type="desktop-id">pronterface.desktop</launchable>
  <screenshots>
   <screenshot type="default" width="1061" height="596">https://raw.github.com/kliment/Printrun/master/screenshots/pronterface.png</screenshot>
   <screenshot width="566" height="626">https://raw.github.com/kliment/Printrun/master/screenshots/pronterface2.png</screenshot>
  </screenshots>
  <url type="homepage">https://github.com/kliment/Printrun</url>
-</application>
+</component>

--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,7 @@ if sys.argv[1] in("install", "uninstall") and len(prefix):
 target_images_path = "share/pronterface/images/"
 data_files = [('share/pixmaps', ['pronterface.png', 'plater.png', 'pronsole.png']),
               ('share/applications', ['pronterface.desktop', 'pronsole.desktop', 'plater.desktop']),
-              ('share/appdata', ['pronterface.appdata.xml', 'pronsole.appdata.xml', 'plater.appdata.xml'])]
+              ('share/metainfo', ['pronterface.appdata.xml', 'pronsole.appdata.xml', 'plater.appdata.xml'])]
 
 for basedir, subdirs, files in os.walk("images"):
     images = []


### PR DESCRIPTION
Move appstream files from /usr/share/appstream to /usr/share/metainfo
and update metadata to AppStream's specification version 0.11