### PR TITLE
Initial port to wxPython 4

### DIFF
--- a/printrun/excluder.py
+++ b/printrun/excluder.py
@@ -24,10 +24,9 @@ class ExcluderWindow(gviz.GvizWindow):
     def __init__(self, excluder, *args, **kwargs):
         super(ExcluderWindow, self).__init__(*args, **kwargs)
         self.SetTitle(_("Part excluder: draw rectangles where print instructions should be ignored"))
-        self.toolbar.AddLabelTool(128, " " + _("Reset selection"),
-                                  wx.Image(imagefile('reset.png'), wx.BITMAP_TYPE_PNG).ConvertToBitmap(),
-                                  shortHelp = _("Reset selection"),
-                                  longHelp = "")
+        self.toolbar.AddTool(128, " " + _("Reset selection"),
+                             wx.Image(imagefile('reset.png'), wx.BITMAP_TYPE_PNG).ConvertToBitmap(),
+                             _("Reset selection"))
         self.Bind(wx.EVT_TOOL, self.reset_selection, id = 128)
         self.parent = excluder
         self.p.paint_overlay = self.paint_selection
@@ -46,7 +45,7 @@ class ExcluderWindow(gviz.GvizWindow):
            or event.ButtonUp(wx.MOUSE_BTN_RIGHT):
             self.initpos = None
         elif event.Dragging() and event.RightIsDown():
-            e = event.GetPositionTuple()
+            e = event.GetPosition()
             if not self.initpos or not hasattr(self, "basetrans"):
                 self.initpos = e
                 self.basetrans = self.p.translate
@@ -55,7 +54,7 @@ class ExcluderWindow(gviz.GvizWindow):
             self.p.dirty = 1
             wx.CallAfter(self.p.Refresh)
         elif event.Dragging() and event.LeftIsDown():
-            x, y = event.GetPositionTuple()
+            x, y = event.GetPosition()
             if not self.initpos:
                 self.basetrans = self.p.translate
             x = (x - self.basetrans[0]) / self.p.scale[0]

--- a/printrun/gcview.py
+++ b/printrun/gcview.py
@@ -237,7 +237,7 @@ class GcodeViewPanel(wxGLPanel):
                 if delta > 0: self.layerup()
                 else: self.layerdown()
             return
-        x, y = event.GetPositionTuple()
+        x, y = event.GetPosition()
         x, y, _ = self.mouse_to_3d(x, y)
         if delta > 0:
             self.zoom(factor, (x, y))

--- a/printrun/gl/panel.py
+++ b/printrun/gl/panel.py
@@ -97,7 +97,7 @@ class wxGLPanel(wx.Panel):
         if self.IsFrozen():
             event.Skip()
             return
-        if (wx.VERSION > (2, 9) and self.canvas.IsShownOnScreen()) or self.canvas.GetContext():
+        if self.canvas.IsShownOnScreen():
             # Make sure the frame is shown before calling SetCurrent.
             self.canvas.SetCurrent(self.context)
             self.OnReshape()
@@ -326,10 +326,10 @@ class wxGLPanel(wx.Panel):
 
     def handle_rotation(self, event):
         if self.initpos is None:
-            self.initpos = event.GetPositionTuple()
+            self.initpos = event.GetPosition()
         else:
             p1 = self.initpos
-            p2 = event.GetPositionTuple()
+            p2 = event.GetPosition()
             sz = self.GetClientSize()
             p1x = float(p1[0]) / (sz[0] / 2) - 1
             p1y = 1 - float(p1[1]) / (sz[1] / 2)
@@ -342,10 +342,10 @@ class wxGLPanel(wx.Panel):
 
     def handle_translation(self, event):
         if self.initpos is None:
-            self.initpos = event.GetPositionTuple()
+            self.initpos = event.GetPosition()
         else:
             p1 = self.initpos
-            p2 = event.GetPositionTuple()
+            p2 = event.GetPosition()
             if self.orthographic:
                 x1, y1, _ = self.mouse_to_3d(p1[0], p1[1])
                 x2, y2, _ = self.mouse_to_3d(p2[0], p2[1])

--- a/printrun/gui/__init__.py
+++ b/printrun/gui/__init__.py
@@ -17,8 +17,10 @@ import logging
 
 try:
     import wx
+    if wx.VERSION < (4,):
+        raise ImportError()
 except:
-    logging.error(_("WX is not installed. This program requires WX to run."))
+    logging.error(_("WX >= 4 is not installed. This program requires WX >= 4 to run."))
     raise
 
 from printrun.utils import install_locale
@@ -202,9 +204,7 @@ class MainWindow(wx.Frame):
         self.Bind(wx.EVT_CLOSE, self.kill)
 
         # Custom buttons
-        if wx.VERSION > (2, 9): self.cbuttonssizer = wx.WrapSizer(wx.HORIZONTAL)
-        else: self.cbuttonssizer = wx.GridBagSizer()
-        self.cbuttonssizer = wx.GridBagSizer()
+        self.cbuttonssizer = wx.WrapSizer(wx.HORIZONTAL)
         self.centerpanel = self.newPanel(page1panel2)
         self.centerpanel.SetSizer(self.cbuttonssizer)
         rightsizer.Add(self.centerpanel, 0, wx.ALIGN_CENTER)
@@ -255,8 +255,7 @@ class MainWindow(wx.Frame):
             logpanel = self.newPanel(left_real_panel)
         viz_pane = VizPane(self, vizpanel)
         # Custom buttons
-        if wx.VERSION > (2, 9): self.cbuttonssizer = wx.WrapSizer(wx.HORIZONTAL)
-        else: self.cbuttonssizer = wx.GridBagSizer()
+        self.cbuttonssizer = wx.WrapSizer(wx.HORIZONTAL)
         self.centerpanel = self.newPanel(vizpanel)
         self.centerpanel.SetSizer(self.cbuttonssizer)
         viz_pane.Add(self.centerpanel, 0, flag = wx.ALIGN_CENTER)

--- a/printrun/gui/bufferedcanvas.py
+++ b/printrun/gui/bufferedcanvas.py
@@ -90,7 +90,7 @@ class BufferedCanvas(wx.Panel):
         self.Refresh()
 
     def getWidthHeight(self):
-        width, height = self.GetClientSizeTuple()
+        width, height = self.GetClientSize()
         if width == 0:
             width = 1
         if height == 0:
@@ -103,7 +103,7 @@ class BufferedCanvas(wx.Panel):
 
     def onPaint(self, event):
         # Blit the front buffer to the screen
-        w, h = self.GetClientSizeTuple()
+        w, h = self.GetClientSize()
         if not w or not h:
             return
         else:

--- a/printrun/gui/toolbar.py
+++ b/printrun/gui/toolbar.py
@@ -27,7 +27,7 @@ def MainToolbar(root, parentpanel = None, use_wrapsizer = False):
         parentpanel = root.newPanel(parentpanel)
         glob.Add(parentpanel, 1, flag = wx.EXPAND)
         glob.Add(root.locker, 0, flag = wx.ALIGN_CENTER)
-    ToolbarSizer = wx.WrapSizer if use_wrapsizer and wx.VERSION > (2, 9) else wx.BoxSizer
+    ToolbarSizer = wx.WrapSizer if use_wrapsizer else wx.BoxSizer
     self = ToolbarSizer(wx.HORIZONTAL)
     root.rescanbtn = make_autosize_button(parentpanel, _("Port"), root.rescanports, _("Communication Settings\nClick to rescan ports"))
     self.Add(root.rescanbtn, 0, wx.TOP | wx.LEFT, 0)

--- a/printrun/gui/widgets.py
+++ b/printrun/gui/widgets.py
@@ -257,7 +257,7 @@ class TempGauge(wx.Panel):
         self.Bind(wx.EVT_PAINT, self.paint)
         self.SetBackgroundStyle(wx.BG_STYLE_CUSTOM)
         self.bgcolor = wx.Colour()
-        self.bgcolor.SetFromName(bgcolor)
+        self.bgcolor.Set(bgcolor)
         self.width, self.height = size
         self.title = title
         self.max = maxval
@@ -292,13 +292,13 @@ class TempGauge(wx.Panel):
         return wx.Colour(*map(int, rgb))
 
     def paint(self, ev):
-        self.width, self.height = self.GetClientSizeTuple()
+        self.width, self.height = self.GetClientSize()
         self.recalc()
         x0, y0, x1, y1, xE, yE = 1, 1, self.ypt + 1, 1, self.width + 1 - 2, 20
         dc = wx.PaintDC(self)
         dc.SetBackground(wx.Brush(self.bgcolor))
         dc.Clear()
-        cold, medium, hot = wx.Colour(0, 167, 223), wx.Colour(239, 233, 119), wx.Colour(210, 50.100)
+        cold, medium, hot = wx.Colour(0, 167, 223), wx.Colour(239, 233, 119), wx.Colour(210, 50, 0)
         # gauge1, gauge2 = wx.Colour(255, 255, 210), (self.gaugeColour or wx.Colour(234, 82, 0))
         gauge1 = wx.Colour(255, 255, 210)
         shadow1, shadow2 = wx.Colour(110, 110, 110), self.bgcolor

--- a/printrun/gui/xybuttons.py
+++ b/printrun/gui/xybuttons.py
@@ -68,7 +68,7 @@ class XYButtons(BufferedCanvas):
         self.lastCorner = None
 
         self.bgcolor = wx.Colour()
-        self.bgcolor.SetFromName(bgcolor)
+        self.bgcolor.Set(bgcolor)
         self.bgcolormask = wx.Colour(self.bgcolor.Red(), self.bgcolor.Green(), self.bgcolor.Blue(), 128)
 
         BufferedCanvas.__init__(self, parent, ID, size=self.bg_bmp.GetSize())
@@ -218,7 +218,7 @@ class XYButtons(BufferedCanvas):
         w, h = self.corner_size
         xinset, yinset = self.corner_inset
         cx, cy = self.center
-        ww, wh = self.GetSizeTuple()
+        ww, wh = self.GetSize()
 
         if corner == 0:
             x, y = (cx - ww / 2 + xinset + 1, cy - wh / 2 + yinset)

--- a/printrun/gui/zbuttons.py
+++ b/printrun/gui/zbuttons.py
@@ -44,7 +44,7 @@ class ZButtons(BufferedCanvas):
         self.lastValue = None
 
         self.bgcolor = wx.Colour()
-        self.bgcolor.SetFromName(bgcolor)
+        self.bgcolor.Set(bgcolor)
         self.bgcolormask = wx.Colour(self.bgcolor.Red(), self.bgcolor.Green(), self.bgcolor.Blue(), 128)
 
         BufferedCanvas.__init__(self, parent, ID, size=self.bg_bmp.GetSize())

--- a/printrun/gviz.py
+++ b/printrun/gviz.py
@@ -38,15 +38,15 @@ class GvizBaseFrame(wx.Frame):
 
         vbox = wx.BoxSizer(wx.VERTICAL)
         self.toolbar = wx.ToolBar(panel, -1, style = wx.TB_HORIZONTAL | wx.NO_BORDER | wx.TB_HORZ_TEXT)
-        self.toolbar.AddSimpleTool(1, wx.Image(imagefile('zoom_in.png'), wx.BITMAP_TYPE_PNG).ConvertToBitmap(), _("Zoom In [+]"), '')
-        self.toolbar.AddSimpleTool(2, wx.Image(imagefile('zoom_out.png'), wx.BITMAP_TYPE_PNG).ConvertToBitmap(), _("Zoom Out [-]"), '')
+        self.toolbar.AddTool(1, '', wx.Image(imagefile('zoom_in.png'), wx.BITMAP_TYPE_PNG).ConvertToBitmap(), _("Zoom In [+]"),)
+        self.toolbar.AddTool(2, '', wx.Image(imagefile('zoom_out.png'), wx.BITMAP_TYPE_PNG).ConvertToBitmap(), _("Zoom Out [-]"))
         self.toolbar.AddSeparator()
-        self.toolbar.AddSimpleTool(3, wx.Image(imagefile('arrow_up.png'), wx.BITMAP_TYPE_PNG).ConvertToBitmap(), _("Move Up a Layer [U]"), '')
-        self.toolbar.AddSimpleTool(4, wx.Image(imagefile('arrow_down.png'), wx.BITMAP_TYPE_PNG).ConvertToBitmap(), _("Move Down a Layer [D]"), '')
-        self.toolbar.AddLabelTool(5, " " + _("Reset view"), wx.Image(imagefile('reset.png'), wx.BITMAP_TYPE_PNG).ConvertToBitmap(), shortHelp = _("Reset view"), longHelp = '')
+        self.toolbar.AddTool(3, '', wx.Image(imagefile('arrow_up.png'), wx.BITMAP_TYPE_PNG).ConvertToBitmap(), _("Move Up a Layer [U]"))
+        self.toolbar.AddTool(4, '', wx.Image(imagefile('arrow_down.png'), wx.BITMAP_TYPE_PNG).ConvertToBitmap(), _("Move Down a Layer [D]"))
+        self.toolbar.AddTool(5, " " + _("Reset view"), wx.Image(imagefile('reset.png'), wx.BITMAP_TYPE_PNG).ConvertToBitmap(), shortHelp = _("Reset view"))
         self.toolbar.AddSeparator()
-        self.toolbar.AddSimpleTool(6, wx.Image(imagefile('inject.png'), wx.BITMAP_TYPE_PNG).ConvertToBitmap(), shortHelpString = _("Inject G-Code"), longHelpString = _("Insert code at the beginning of this layer"))
-        self.toolbar.AddSimpleTool(7, wx.Image(imagefile('edit.png'), wx.BITMAP_TYPE_PNG).ConvertToBitmap(), shortHelpString = _("Edit layer"), longHelpString = _("Edit the G-Code of this layer"))
+        self.toolbar.AddTool(6, '', wx.Image(imagefile('inject.png'), wx.BITMAP_TYPE_PNG).ConvertToBitmap(), wx.NullBitmap, shortHelp = _("Inject G-Code"), longHelp = _("Insert code at the beginning of this layer"))
+        self.toolbar.AddTool(7, '', wx.Image(imagefile('edit.png'), wx.BITMAP_TYPE_PNG).ConvertToBitmap(), wx.NullBitmap, shortHelp = _("Edit layer"), longHelp = _("Edit the G-Code of this layer"))
 
         vbox.Add(self.toolbar, 0, border = 5)
 
@@ -120,7 +120,7 @@ class GvizWindow(GvizBaseFrame):
             if self.initpos is not None:
                 self.initpos = None
         elif event.Dragging():
-            e = event.GetPositionTuple()
+            e = event.GetPosition()
             if self.initpos is None:
                 self.initpos = e
                 self.basetrans = self.p.translate
@@ -197,19 +197,19 @@ class Gviz(wx.Panel):
         self.arcpen = wx.Pen(wx.Colour(255, 0, 0), penwidth)
         self.travelpen = wx.Pen(wx.Colour(10, 80, 80), penwidth)
         self.hlpen = wx.Pen(wx.Colour(200, 50, 50), penwidth)
-        self.fades = [wx.Pen(wx.Colour(250 - 0.6 ** i * 100, 250 - 0.6 ** i * 100, 200 - 0.4 ** i * 50), penwidth) for i in xrange(6)]
+        self.fades = [wx.Pen(wx.Colour(int(250 - 0.6 ** i * 100), int(250 - 0.6 ** i * 100), int(200 - 0.4 ** i * 50)), penwidth) for i in xrange(6)]
         self.penslist = [self.mainpen, self.travelpen, self.hlpen] + self.fades
         self.bgcolor = wx.Colour()
-        self.bgcolor.SetFromName(bgcolor)
-        self.blitmap = wx.EmptyBitmap(self.GetClientSize()[0], self.GetClientSize()[1], -1)
+        self.bgcolor.Set(bgcolor)
+        self.blitmap = wx.Bitmap(self.GetClientSize()[0], self.GetClientSize()[1], -1)
         self.paint_overlay = None
 
     def inject(self):
-        layer = self.layers.index(self.layerindex)
+        layer = self.layers[self.layerindex]
         injector(self.gcode, self.layerindex, layer)
 
     def editlayer(self):
-        layer = self.layers.index(self.layerindex)
+        layer = self.layers[self.layerindex]
         injector_edit(self.gcode, self.layerindex, layer)
 
     def clearhilights(self):
@@ -275,7 +275,7 @@ class Gviz(wx.Panel):
 
     def resize(self, event):
         old_basescale = self.basescale
-        width, height = self.GetClientSizeTuple()
+        width, height = self.GetClientSize()
         if width < 1 or height < 1:
             return
         self.size = (width, height)
@@ -325,7 +325,7 @@ class Gviz(wx.Panel):
     def repaint_everything(self):
         width = self.scale[0] * self.build_dimensions[0]
         height = self.scale[1] * self.build_dimensions[1]
-        self.blitmap = wx.EmptyBitmap(width + 1, height + 1, -1)
+        self.blitmap = wx.Bitmap(width + 1, height + 1, -1)
         dc = wx.MemoryDC()
         dc.SelectObject(self.blitmap)
         dc.SetBackground(wx.Brush((250, 250, 200)))

--- a/printrun/objectplater.py
+++ b/printrun/objectplater.py
@@ -96,11 +96,11 @@ class PlaterPanel(wx.Panel):
         if hasattr(viewer, "handle_rotation"):
             def handle_rotation(self, event, orig_handler):
                 if self.initpos is None:
-                    self.initpos = event.GetPositionTuple()
+                    self.initpos = event.GetPosition()
                 else:
                     if event.ShiftDown():
                         p1 = self.initpos
-                        p2 = event.GetPositionTuple()
+                        p2 = event.GetPosition()
                         x1, y1, _ = self.mouse_to_3d(p1[0], p1[1])
                         x2, y2, _ = self.mouse_to_3d(p2[0], p2[1])
                         self.parent.move_shape((x2 - x1, y2 - y1))

--- a/printrun/projectlayer.py
+++ b/printrun/projectlayer.py
@@ -36,8 +36,8 @@ class DisplayFrame(wx.Frame):
         self.printer = printer
         self.control_frame = parent
         self.pic = wx.StaticBitmap(self)
-        self.bitmap = wx.EmptyBitmap(*res)
-        self.bbitmap = wx.EmptyBitmap(*res)
+        self.bitmap = wx.Bitmap(*res)
+        self.bbitmap = wx.Bitmap(*res)
         self.slicer = 'bitmap'
         self.dpi = 96
         dc = wx.MemoryDC()
@@ -73,8 +73,8 @@ class DisplayFrame(wx.Frame):
             pass
 
     def resize(self, res = (1024, 768)):
-        self.bitmap = wx.EmptyBitmap(*res)
-        self.bbitmap = wx.EmptyBitmap(*res)
+        self.bitmap = wx.Bitmap(*res)
+        self.bbitmap = wx.Bitmap(*res)
         dc = wx.MemoryDC()
         dc.SelectObject(self.bbitmap)
         dc.SetBackground(wx.Brush("black"))
@@ -624,7 +624,7 @@ class SettingsFrame(wx.Frame):
             resolution_x_pixels = int(self.X.GetValue())
             resolution_y_pixels = int(self.Y.GetValue())
 
-            gridBitmap = wx.EmptyBitmap(resolution_x_pixels, resolution_y_pixels)
+            gridBitmap = wx.Bitmap(resolution_x_pixels, resolution_y_pixels)
             dc = wx.MemoryDC()
             dc.SelectObject(gridBitmap)
             dc.SetBackground(wx.Brush("black"))

--- a/printrun/pronterface.py
+++ b/printrun/pronterface.py
@@ -41,8 +41,11 @@ install_locale('pronterface')
 
 try:
     import wx
+    import wx.adv
+    if wx.VERSION < (4,):
+        raise ImportError()
 except:
-    logging.error(_("WX is not installed. This program requires WX to run."))
+    logging.error(_("WX >= 4 is not installed. This program requires WX >= 4 to run."))
     raise
 
 from .gui.widgets import SpecialButton, MacroEditor, PronterOptions, ButtonEdit
@@ -725,7 +728,7 @@ class PronterWindow(MainWindow, pronsole.pronsole):
         self.filehistory.UseMenu(recent)
         self.Bind(wx.EVT_MENU_RANGE, self.load_recent_file,
                   id = wx.ID_FILE1, id2 = wx.ID_FILE9)
-        m.AppendMenu(wx.ID_ANY, _("&Recent Files"), recent)
+        m.Append(wx.ID_ANY, _("&Recent Files"), recent)
         self.Bind(wx.EVT_MENU, self.clear_log, m.Append(-1, _("Clear console"), _(" Clear output console")))
         self.Bind(wx.EVT_MENU, self.on_exit, m.Append(wx.ID_EXIT, _("E&xit"), _(" Closes the Window")))
         self.menustrip.Append(m, _("&File"))
@@ -814,7 +817,7 @@ class PronterWindow(MainWindow, pronsole.pronsole):
     def about(self, event):
         """Show about dialog"""
 
-        info = wx.AboutDialogInfo()
+        info = wx.adv.AboutDialogInfo()
 
         info.SetIcon(wx.Icon(iconfile("pronterface.png"), wx.BITMAP_TYPE_PNG))
         info.SetName('Printrun')
@@ -848,7 +851,7 @@ Printrun. If not, see <http://www.gnu.org/licenses/>."""
         info.AddDeveloper('Kliment Yanev')
         info.AddDeveloper('Guillaume Seguin')
 
-        wx.AboutBox(info)
+        wx.adv.AboutBox(info)
 
     #  --------------------------------------------------------------
     #  Settings & command line handling (including update callbacks)

--- a/printrun/settings.py
+++ b/printrun/settings.py
@@ -39,7 +39,7 @@ def setting_add_tooltip(func):
                 deftxt += repr(self.default) + "  " + resethelp
         helptxt += sep + deftxt
         if len(helptxt):
-            widget.SetToolTipString(helptxt)
+            widget.SetToolTip(helptxt)
         return widget
     return decorator
 

--- a/printrun/spoolmanager/spoolmanager_gui.py
+++ b/printrun/spoolmanager/spoolmanager_gui.py
@@ -46,11 +46,11 @@ class SpoolManagerMainWindow(wx.Frame):
 
         # Generate the buttons
         self.new_button = wx.Button(self, wx.ID_ADD)
-        self.new_button.SetToolTipString("Add a new spool")
+        self.new_button.SetToolTip("Add a new spool")
         self.edit_button = wx.Button(self, wx.ID_EDIT)
-        self.edit_button.SetToolTipString("Edit the selected spool")
+        self.edit_button.SetToolTip("Edit the selected spool")
         self.delete_button = wx.Button(self, wx.ID_DELETE)
-        self.delete_button.SetToolTipString("Delete the selected spool")
+        self.delete_button.SetToolTip("Delete the selected spool")
 
         # "Program" the buttons
         self.new_button.Bind(wx.EVT_BUTTON, self.onClickAdd)
@@ -220,10 +220,10 @@ class CurrentSpoolDialog(wx.Panel):
 
             # Generate the "load" and "unload" buttons
             load_button.append(wx.Button(self, label = "Load"))
-            load_button[i].SetToolTipString(
+            load_button[i].SetToolTip(
                 "Load selected spool for Extruder %d" % i)
             unload_button.append(wx.Button(self, label = "Unload"))
-            unload_button[i].SetToolTipString(
+            unload_button[i].SetToolTip(
                 "Unload the spool for Extruder %d" % i)
 
             # "Program" the buttons
@@ -241,7 +241,7 @@ class CurrentSpoolDialog(wx.Panel):
 
             dialog_sizer.append(wx.BoxSizer(wx.HORIZONTAL))
             dialog_sizer[i].Add(self.extruder_dialog[i], 1, wx.ALIGN_CENTER)
-            dialog_sizer[i].AddSpacer((10, -1))
+            dialog_sizer[i].AddSpacer(10)
             dialog_sizer[i].Add(button_sizer[i], 0, wx.EXPAND)
 
             full_sizer.Add(dialog_sizer[i], 0, wx.ALL | wx.EXPAND, 10)
@@ -310,13 +310,13 @@ class SpoolManagerAddWindow(wx.Frame):
             "Name", "Default Spool", "")
         self.diameter_dialog = LabeledTextCtrl(self,
             "Diameter", "1.75", "mm")
-        self.diameter_dialog.SetToolTipString(
+        self.diameter_dialog.SetToolTip(
             "Typically, either 1.75 mm or 2.85 mm (a.k.a '3')")
         self.weight_dialog = LabeledTextCtrl(self,
             "Weight", "1", "Kg")
         self.density_dialog = LabeledTextCtrl(self,
             "Density", "1.25", "g/cm^3")
-        self.density_dialog.SetToolTipString(
+        self.density_dialog.SetToolTip(
             "Typical densities are 1.25 g/cm^3 for PLA and 1.08 g/cm^3 for" +
             " ABS")
         self.length_dialog = LabeledTextCtrl(self,

--- a/printrun/stlplater.py
+++ b/printrun/stlplater.py
@@ -74,7 +74,7 @@ class showstl(wx.Window):
         self.prevsel = -1
 
     def prepare_model(self, m, scale):
-        m.bitmap = wx.EmptyBitmap(800, 800, 32)
+        m.bitmap = wx.Bitmap(800, 800, 32)
         dc = wx.MemoryDC()
         dc.SelectObject(m.bitmap)
         dc.SetBackground(wx.Brush((0, 0, 0, 0)))
@@ -105,7 +105,7 @@ class showstl(wx.Window):
     def move(self, event):
         if event.ButtonUp(wx.MOUSE_BTN_LEFT):
             if self.initpos is not None:
-                currentpos = event.GetPositionTuple()
+                currentpos = event.GetPosition()
                 delta = (0.5 * (currentpos[0] - self.initpos[0]),
                          -0.5 * (currentpos[1] - self.initpos[1])
                          )
@@ -116,10 +116,10 @@ class showstl(wx.Window):
             self.parent.right(event)
         elif event.Dragging():
             if self.initpos is None:
-                self.initpos = event.GetPositionTuple()
+                self.initpos = event.GetPosition()
             self.Refresh()
             dc = wx.ClientDC(self)
-            p = event.GetPositionTuple()
+            p = event.GetPosition()
             dc.DrawLine(self.initpos[0], self.initpos[1], p[0], p[1])
             del dc
         else:

--- a/printrun/stlview.py
+++ b/printrun/stlview.py
@@ -167,7 +167,7 @@ class StlViewPanel(wxGLPanel):
         RMB: nothing
             with shift move viewport
         """
-        self.mousepos = event.GetPositionTuple()
+        self.mousepos = event.GetPosition()
         if event.Dragging() and event.LeftIsDown():
             self.handle_rotation(event)
         elif event.Dragging() and event.RightIsDown():
@@ -187,7 +187,7 @@ class StlViewPanel(wxGLPanel):
     def handle_wheel(self, event):
         delta = event.GetWheelRotation()
         factor = 1.05
-        x, y = event.GetPositionTuple()
+        x, y = event.GetPosition()
         x, y, _ = self.mouse_to_3d(x, y, local_transform = True)
         if delta > 0:
             self.zoom(factor, (x, y))

--- a/pronterface.py
+++ b/pronterface.py
@@ -21,8 +21,10 @@ import getopt
 
 try:
     import wx  # NOQA
+    if wx.VERSION < (4,):
+        raise ImportError()
 except:
-    print("wxPython is not installed. This program requires wxPython to run.")
+    print("wxPython >= 4 is not installed. This program requires wxPython >=4 to run.")
     if sys.version_info.major >= 3:
         print("""\
 As you are currently running python3, this is most likely because wxPython is

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 python (>= 2.7, << 3)
 pyreadline
 pyserial (>= 2.6)
-wxPython (>= 2.8, << 4.0)
+wxPython (>= 4.0)
 numpy (>= 1.8.2)
 pyglet (>= 1.1)
 pycairo (>= 1.8.8)


### PR DESCRIPTION
See https://github.com/kliment/Printrun/issues/882

I don't see more tracebacks.

I see a lot of:

```
17:43:43: Debug: Unsupported OpenGL attribute 114
17:43:43: Debug: Unsupported OpenGL attribute 111
17:43:43: Debug: Unsupported OpenGL attribute 110
17:43:43: Debug: Unsupported OpenGL attribute 116
17:43:43: Debug: Unsupported OpenGL attribute 101
17:43:43: Debug: Unsupported OpenGL attribute 114
17:43:43: Debug: Unsupported OpenGL attribute 102
17:43:43: Debug: Unsupported OpenGL attribute 97
17:43:43: Debug: Unsupported OpenGL attribute 99
17:43:43: Debug: Unsupported OpenGL attribute 101
```

And (this happens with wxPython 3 as well):

```
(pronterface.py:...): Gtk-CRITICAL **: gtk_box_gadget_distribute: assertion 'size >= 0' failed in GtkSpinButton
```