### PR TITLE
Fix #908

### DIFF
--- a/printrun/gui/zbuttons.py
+++ b/printrun/gui/zbuttons.py
@@ -146,7 +146,7 @@ class ZButtons(BufferedCanvas):
 
         mpos = event.GetPosition()
         r, d = self.getRangeDir(mpos)
-        if r >= 0:
+        if r is not None and r >= 0:
             value = d * self.move_values[r]
             if self.moveCallback:
                 self.lastValue = value


### PR DESCRIPTION
In Python 2, `None >= 0` was `False`. Now it's `TypeError`.

Fixes https://github.com/kliment/Printrun/issues/908