### PR TITLE
Put bytes instead of str to CoreFoundation.CFStringCreateWithCString

### DIFF
--- a/printrun/power/osx.py
+++ b/printrun/power/osx.py
@@ -41,6 +41,7 @@ def StringToCFString(string):
         encoding = CoreFoundation.kCFStringEncodingASCII
     except AttributeError:
         encoding = 0x600
+    string = string.encode('ascii')
     cfstring = CoreFoundation.CFStringCreateWithCString(None, string, encoding)
     return objc.pyobjc_id(cfstring.nsstring())
 


### PR DESCRIPTION
The exception was:

    ValueError: Expecting byte string of length 1, got a 'str'

Yet bytes with any length appears to work, so i assume it is bogus.

Fixes https://github.com/kliment/Printrun/issues/619#issuecomment-383080135