### PR TITLE
distutils didn't like trailing '/'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,7 +125,7 @@ if not prefix or not len(prefix):
 if sys.argv[1] in("install", "uninstall") and len(prefix):
     sys.argv += ["--prefix", prefix]
 
-target_images_path = "share/pronterface/images/"
+target_images_path = "share/pronterface/images"
 data_files = [('share/pixmaps', ['pronterface.png', 'plater.png', 'pronsole.png']),
               ('share/applications', ['pronterface.desktop', 'pronsole.desktop', 'plater.desktop']),
               ('share/metainfo', ['pronterface.appdata.xml', 'pronsole.appdata.xml', 'plater.appdata.xml'])]


### PR DESCRIPTION
running install_data
Traceback (most recent call last):
  File "setup.py", line 173, in <module>
    classifiers=["Programming Language :: Python :: 3 :: Only"],
  File "C:\Python36\lib\distutils\core.py", line 148, in setup
    dist.run_commands()
  File "C:\Python36\lib\distutils\dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "C:\Python36\lib\distutils\dist.py", line 974, in run_command
    cmd_obj.run()
  File "setup.py", line 44, in run
    _install.run(self)
  File "C:\Python36\lib\distutils\command\install.py", line 557, in run
    self.run_command(cmd_name)
  File "C:\Python36\lib\distutils\cmd.py", line 313, in run_command
    self.distribution.run_command(command)
  File "C:\Python36\lib\distutils\dist.py", line 974, in run_command
    cmd_obj.run()
  File "setup.py", line 72, in run
    _install_data.run(self)
  File "C:\Python36\lib\distutils\command\install_data.py", line 56, in run
    dir = convert_path(f[0])
  File "C:\Python36\lib\distutils\util.py", line 127, in convert_path
    raise ValueError("path '%s' cannot end with '/'" % pathname)
ValueError: path 'share/pronterface/images/' cannot end with '/'

C:\Users\ernest\git\Printrun>