### PR TITLE
fix for issue #676, preset temperatures aren't read from the rc file

### DIFF
--- a/printrun/settings.py
+++ b/printrun/settings.py
@@ -364,7 +364,7 @@ class Settings:
         try:
             cb = None
             try:
-                cb = getattr(self, "__%s_cb" % key)
+                cb = getattr(self, "_%s_cb" % key)
             except AttributeError:
                 pass
             if cb is not None: cb(key, value)


### PR DESCRIPTION
settings.py expected __whatever_cb functions, but _whatever_cb functions
had been set up. i adjusted settings to look for _whatever_cb.