### PR TITLE
AttributeError: 'str' object has no attribute 'decode'

### DIFF
--- a/printrun/pronsole.py
+++ b/printrun/pronsole.py
@@ -743,7 +743,6 @@ class pronsole(cmd.Cmd):
         self.processing_args = False
         self.update_rpc_server(None, self.settings.rpc_server)
         if args.filename:
-            filename = args.filename.decode(locale.getpreferredencoding())
             self.cmdline_filename_callback(filename)
 
     def cmdline_filename_callback(self, filename):

--- a/printrun/pronsole.py
+++ b/printrun/pronsole.py
@@ -743,7 +743,7 @@ class pronsole(cmd.Cmd):
         self.processing_args = False
         self.update_rpc_server(None, self.settings.rpc_server)
         if args.filename:
-            self.cmdline_filename_callback(filename)
+            self.cmdline_filename_callback(args.filename)
 
     def cmdline_filename_callback(self, filename):
         self.do_load(filename)


### PR DESCRIPTION
args.filename is a str in Python 3, needs no decoding