### PR TITLE
add piping and stdin redirection

### DIFF
--- a/printrun/pronsole.py
+++ b/printrun/pronsole.py
@@ -254,7 +254,10 @@ class pronsole(cmd.Cmd):
                     pass
 
     def confirm(self):
-        y_or_n = input("y/n: ")
+        try:
+            y_or_n = input("y/n: ")
+        except EOFError:
+            return False
         if y_or_n == "y":
             return True
         elif y_or_n != "n":


### PR DESCRIPTION
Command piping and input redirecting fails here end of line Ctrl-R
terminates whole terminal 
Example: echo"connect;load file.gcode;print" | pronsole 
idea behind this is to have script written as text format and execute lines 1 by 1
 via stdin similar to fire and forget