### PR TITLE
Fix an issue with running "Final command" when print is finished 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,13 @@ uploads
 .DS_Store
 .vagrant
 prontserve-env
+pronterface.spec
 printrun/gcoder_line.c
 printrun/gcoder_line*.so
+printrun/gcoder_line*.pyd
 .project
 .pydevproject
 /build/
+/dist/
 /venv/
+/.vscode/

--- a/printrun/pronsole.py
+++ b/printrun/pronsole.py
@@ -1279,8 +1279,6 @@ class pronsole(cmd.Cmd):
                             self.spool_manager.editLength(
                                 -self.fgcode.filament_length, extruder = 0)
 
-        else:
-
             if not self.settings.final_command:
                 return
             output = get_command_output(self.settings.final_command,


### PR DESCRIPTION
The "Final command" would only be executed when the print has ended but not fully finished. Make sure it always runs by removing this condition.

Also, extend the .gitignore file with some (Windows) build artifacts.