### PR TITLE
FIx a crash when starting pronterface due to locale settings

### DIFF
--- a/printrun/pronterface.py
+++ b/printrun/pronterface.py
@@ -2393,5 +2393,6 @@ class PronterApp(wx.App):
     def __init__(self, *args, **kwargs):
         super(PronterApp, self).__init__(*args, **kwargs)
         self.SetAppName("Pronterface")
+        self.locale = wx.Locale(wx.Locale.GetSystemLanguage())
         self.mainwindow = PronterWindow(self)
         self.mainwindow.Show()


### PR DESCRIPTION
When starting pronterface on Windows 10 (1903 18362.296), wxWidgets
throws an error due to inconsistent locale settings:

Traceback (most recent call last):
  File "pronterface.py", line 62, in <module>
    app = PronterApp(False)
  File "Printrun\printrun\pronterface.py", line 2396, in __init__
    self.mainwindow = PronterWindow(self)
  File "Printrun\printrun\pronterface.py", line 187, in __init__
    self.SetIcon(wx.Icon(iconfile("pronterface.png"), wx.BITMAP_TYPE_PNG))
wx._core.wxAssertionError: C++ assertion "strcmp(setlocale(LC_ALL, NULL), "C") == 0" failed at ..\..\src\common\intl.cpp(1579) in wxLocale::GetInfo(): You probably called setlocale() directly instead of using wxLocale and now there is a mismatch between C/C++ and Windows locale.

Fix this issue by specifying the locale on the pronterface app using wxLocale,
as suggested by the assertion.