### PR TITLE
Make the Printrun project own GCoder files

### DIFF
--- a/printrun/gcoder.py
+++ b/printrun/gcoder.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
-# This file is copied from GCoder.
 #
-# GCoder is free software: you can redistribute it and/or modify
+# This file is part of the Printrun suite.
+#
+# Printrun is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# GCoder is distributed in the hope that it will be useful,
+# Printrun is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.

--- a/printrun/gcoder_line.pyx
+++ b/printrun/gcoder_line.pyx
@@ -1,13 +1,13 @@
 #cython: language_level=3
 #
-# This file is copied from GCoder.
+# This file is part of the Printrun suite.
 #
-# GCoder is free software: you can redistribute it and/or modify
+# Printrun is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# GCoder is distributed in the hope that it will be useful,
+# Printrun is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.


### PR DESCRIPTION
Dear @sivu  and @iXce , I believe you were the ones that produced these files a long long time ago, so I would like your approval for this change. Please let me know what you think.
 
 The reason behind this is that it has been picked up that the sentence "This file is copied from GCoder" is misleading in legal terms and makes it impossible to determine either licence or copyright holders. With the change I'm proposing these files will simply fall within the project-wide licence (GPL-3+) and project copyright holders.