### PR TITLE
Update metadata to AppStream's spec 0.12

### DIFF
--- a/plater.appdata.xml
+++ b/plater.appdata.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
- <id>plater</id>
- <metadata_license>FSFAP</metadata_license>
- <project-license>GPL-3.0+</project-license>
+ <id>com.github.kliment/printrun/plater</id>
+ <metadata_license>CC0-1.0</metadata_license>
+ <project_license>GPL-3.0+</project_license>
  <name>Plater</name>
  <summary>3D printer plating tool</summary>
  <description>
@@ -11,7 +11,9 @@
  </description>
  <launchable type="desktop-id">plater.desktop</launchable>
  <screenshots>
-  <screenshot type="default" width="804" height="606">https://raw.github.com/kliment/Printrun/master/screenshots/plater.png</screenshot>
+   <screenshot type="default">
+     <image width="804" height="606">https://raw.github.com/kliment/Printrun/master/screenshots/plater.png</image>
+   </screenshot>
  </screenshots>
  <url type="homepage">https://github.com/kliment/Printrun</url>
 </component>

--- a/plater.appdata.xml
+++ b/plater.appdata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
- <id>com.github.kliment/printrun/plater</id>
+ <id>com.github.kliment.printrun.plater</id>
  <metadata_license>CC0-1.0</metadata_license>
  <project_license>GPL-3.0+</project_license>
  <name>Plater</name>

--- a/pronsole.appdata.xml
+++ b/pronsole.appdata.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
- <id>pronsole</id>
- <metadata_license>FSFAP</metadata_license>
- <project-license>GPL-3.0+</project-license>
+ <id>com.github.kliment.printrun.pronsole</id>
+ <metadata_license>CC0-1.0</metadata_license>
+ <project_license>GPL-3.0+</project_license>
  <name>Pronsole</name>
  <summary>3D printer host software for console</summary>
  <description>
@@ -12,7 +12,9 @@
  </description>
  <launchable type="desktop-id">pronsole.desktop</launchable>
  <screenshots>
-  <screenshot type="default" width="659" height="388">https://raw.github.com/kliment/Printrun/master/screenshots/pronsole.png</screenshot>
+   <screenshot type="default">
+     <image width="659" height="388">https://raw.github.com/kliment/Printrun/master/screenshots/pronsole.png</image>
+   </screenshot>
  </screenshots>
  <url type="homepage">https://github.com/kliment/Printrun</url>
 </component>

--- a/pronterface.appdata.xml
+++ b/pronterface.appdata.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
- <id>pronterface</id>
- <metadata_license>FSFAP</metadata_license>
- <project-license>GPL-3.0+</project-license>
+ <id>com.github.kliment.printrun.pronterface</id>
+ <metadata_license>CC0-1.0</metadata_license>
+ <project_license>GPL-3.0+</project_license>
  <name>Pronterface</name>
  <summary>3D printer host software</summary>
  <description>
@@ -12,8 +12,12 @@
  </description>
  <launchable type="desktop-id">pronterface.desktop</launchable>
  <screenshots>
-  <screenshot type="default" width="1061" height="596">https://raw.github.com/kliment/Printrun/master/screenshots/pronterface.png</screenshot>
-  <screenshot width="566" height="626">https://raw.github.com/kliment/Printrun/master/screenshots/pronterface2.png</screenshot>
+   <screenshot type="default">
+     <image width="1061" height="596">https://raw.github.com/kliment/Printrun/master/screenshots/pronterface.png</image>
+   </screenshot>
+   <screenshot>
+     <image width="566" height="626">https://raw.github.com/kliment/Printrun/master/screenshots/pronterface2.png</image>
+   </screenshot>
  </screenshots>
  <url type="homepage">https://github.com/kliment/Printrun</url>
 </component>


### PR DESCRIPTION
Hi @hroncok you wrote these files a long time ago and licenced them under the CC0 license. I modified them after that and relicensed them to FSFAF without asking anyone (shame on me). So I've reverted that change and updated the files to the latest standard. Do you agree with these changes? Specially the id tag change?
 
The reason behind this is that these issues were picked up by the Debian automated checking system [[1]].
 
[1]: https://appstream.debian.org/sid/main/issues/pronterface.html