### PR TITLE
Setup GitHub actions to build and publish sdist and wheels

### DIFF
--- a/.github/workflows/pypi-mac.yml
+++ b/.github/workflows/pypi-mac.yml
@@ -1,0 +1,45 @@
+name: Build Mac OS X Python package
+
+on:
+  push:
+  pull_request:
+  release:
+    types:
+      - created
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [macos-latest]
+        architecture: [x64]
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        architecture: ${{ matrix.architecture }}
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel twine cython
+    - name: Build Python wheel
+      run: |
+        python setup.py bdist_wheel
+    - name: Upload artifacts for inspection
+      uses: actions/upload-artifact@v2
+      with:
+        name: wheel_${{ matrix.os }}_${{ matrix.architecture }}_${{ matrix.python-version }}
+        path: dist/*.whl
+    - name: Publish sdists and wheels to PyPI
+      if: ${{ success() && github.event_name == 'release' && github.event.action == 'created' }}
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_KEY }}
+      run: |
+        twine upload dist/*

--- a/.github/workflows/pypi-manylinux1.yml
+++ b/.github/workflows/pypi-manylinux1.yml
@@ -1,0 +1,39 @@
+name: Build manylinux1 x86_64 Python package
+
+on:
+  push:
+  pull_request:
+  release:
+    types:
+      - created
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.x
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel twine
+    - name: Build manylinux Python wheels
+      uses: RalfG/python-wheels-manylinux-build@v0.3-manylinux1_x86_64
+      with:
+        python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38'
+        build-requirements: 'cython'
+    - name: Upload artifacts for inspection
+      uses: actions/upload-artifact@v2
+      with:
+        name: manylinux1_wheels
+        path: dist/*.whl
+    - name: Publish sdists and wheels to PyPI
+      if: ${{ success() && github.event_name == 'release' && github.event.action == 'created' }}
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_KEY }}
+      run: |
+        twine upload dist/*

--- a/.github/workflows/pypi-sdist.yml
+++ b/.github/workflows/pypi-sdist.yml
@@ -1,0 +1,37 @@
+name: Create sdists package
+
+on:
+  push:
+  pull_request:
+  release:
+    types:
+      - created
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.x
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel twine
+    - name: Create sdist
+      run: |
+        python setup.py sdist
+    - name: Upload artifacts for inspection
+      uses: actions/upload-artifact@v2
+      with:
+        name: sdist
+        path: dist/*.tar.gz
+    - name: Publish sdists and wheels to PyPI
+      if: ${{ success() && github.event_name == 'release' && github.event.action == 'created' }}
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_KEY }}
+      run: |
+        twine upload dist/*

--- a/.github/workflows/pypi-win.yml
+++ b/.github/workflows/pypi-win.yml
@@ -1,0 +1,44 @@
+name: Build Windows Python package
+
+on:
+  push:
+  pull_request:
+  release:
+    types:
+      - created
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [windows-latest]
+        architecture: [x64, x86]
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.x
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel twine cython
+    - name: Build Python wheel
+      run: |
+        python setup.py bdist_wheel
+    - name: Upload artifacts for inspection
+      uses: actions/upload-artifact@v2
+      with:
+        name: wheel_${{ matrix.os }}_${{ matrix.architecture }}_${{ matrix.python-version }}
+        path: dist/*.whl
+    - name: Publish sdists and wheels to PyPI
+      if: ${{ success() && github.event_name == 'release' && github.event.action == 'created' }}
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_KEY }}
+      run: |
+        twine upload dist/*


### PR DESCRIPTION
Followups:

- [x] [Create and store encrypted secrets](https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets)
- [ ] Release rc6
- [ ] Update installation instructions in the README