### PR TITLE
Allow spaces between X(space)Coordinate

### DIFF
--- a/printrun/gcoder.py
+++ b/printrun/gcoder.py
@@ -25,7 +25,7 @@ from array import array
 gcode_parsed_args = ["x", "y", "e", "f", "z", "i", "j"]
 gcode_parsed_nonargs = ["g", "t", "m", "n"]
 to_parse = "".join(gcode_parsed_args + gcode_parsed_nonargs)
-gcode_exp = re.compile("\([^\(\)]*\)|;.*|[/\*].*\n|([%s])([-+]?[0-9]*\.?[0-9]*)" % to_parse)
+gcode_exp = re.compile("\([^\(\)]*\)|;.*|[/\*].*\n|([%s])\s*([-+]?[0-9]*\.?[0-9]*)" % to_parse)
 gcode_strip_comment_exp = re.compile("\([^\(\)]*\)|;.*|[/\*].*\n")
 m114_exp = re.compile("\([^\(\)]*\)|[/\*].*\n|([XYZ]):?([-+]?[0-9]*\.?[0-9]*)")
 specific_exp = "(?:\([^\(\)]*\))|(?:;.*)|(?:[/\*].*\n)|(%s[-+]?[0-9]*\.?[0-9]*)"


### PR DESCRIPTION
A different solution would be to strip all spaces from the gcode line before parsing.

Inkscape gcodetools produces gcode with whitespace like `G02 X 447.2989 Y 628.0176 Z -0.1250 I -153.8298 J 36.9056 F 400.0000`