### PR TITLE
Fix incorrect string comparisons using "is"

### DIFF
--- a/printrun/pronsole.py
+++ b/printrun/pronsole.py
@@ -420,7 +420,7 @@ class pronsole(cmd.Cmd):
                 self.log("Setting bed temp to 0")
             self.p.send_now("M140 S0.0")
         self.log("Disconnecting from printer...")
-        if self.p.printing and l is not "force":
+        if self.p.printing and l != "force":
             self.log(_("Are you sure you want to exit while printing?\n\
 (this will terminate the print)."))
             if not self.confirm():

--- a/printrun/settings.py
+++ b/printrun/settings.py
@@ -32,7 +32,7 @@ def setting_add_tooltip(func):
             sep = "\n"
             if helptxt.find("\n") >= 0:
                 sep = "\n\n"
-        if self.default is not "":
+        if self.default != "":
             deftxt = _("Default: ")
             resethelp = _("(Control-doubleclick to reset to default value)")
             if len(repr(self.default)) > 10:
@@ -113,7 +113,7 @@ class wxSetting(Setting):
         self.value = self.widget.GetValue()
 
     def set_default(self, e):
-        if e.CmdDown() and e.ButtonDClick() and self.default is not "":
+        if e.CmdDown() and e.ButtonDClick() and self.default != "":
             self.widget.SetValue(self.default)
         else:
             e.Skip()


### PR DESCRIPTION
Python 3.8 complains with a SyntaxWarning about these string comparisons using "is".
Switch them to "!=" instead.