### PR TITLE
Fix 1103: Make M114 "Count" detection more specific

### DIFF
--- a/printrun/pronsole.py
+++ b/printrun/pronsole.py
@@ -1292,7 +1292,7 @@ class pronsole(cmd.Cmd):
 
     def recvcb_report(self, l):
         isreport = REPORT_NONE
-        if "ok C:" in l or "Count" in l \
+        if "ok C:" in l or " Count " in l \
            or ("X:" in l and len(gcoder.m114_exp.findall(l)) == 6):
             self.posreport = l
             isreport = REPORT_POS


### PR DESCRIPTION
Any line containing "Count" is being detected as M114 output, so for
example any string containing the word "Counter-Clockwise" gets
swallowed.

By changing the test to ``" Count "`` this should be improved.

Fixes #1103