### PR TITLE
fix stuck forever when call startprint on printcore

### DIFF
--- a/printrun/printcore.py
+++ b/printrun/printcore.py
@@ -496,7 +496,6 @@ class printcore():
         self._send("M110", -1, True)
         if not gcode or not gcode.lines:
             return True
-        self.clear = False
         resuming = (startindex != 0)
         self.print_thread = threading.Thread(target = self._print,
                                              name = 'print thread',

--- a/printrun/printcore.py
+++ b/printrun/printcore.py
@@ -493,9 +493,11 @@ class printcore():
         self.printing = True
         self.lineno = 0
         self.resendfrom = -1
-        self._send("M110", -1, True)
+        
         if not gcode or not gcode.lines:
             return True
+        self.clear=False 
+        self._send("M110", -1, True)# this to makesure connection if connection fail will be trap on wait and self.clear should set to false first
         resuming = (startindex != 0)
         self.print_thread = threading.Thread(target = self._print,
                                              name = 'print thread',


### PR DESCRIPTION
this simple fix for #1124 there is race condition variable self. clear sometimes set to be false and stuck forever without sent the command at _sendnext