### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pyserial (>= 3.0)
-wxPython (>= 4.1)
+wxPython (== 4.1.0)
 numpy (>= 1.8.2)
 pyglet (>= 1.1)
 cffi


### PR DESCRIPTION
wxPython 4.1.1 has a bug that breaks 3d view, This change pins to the last working version.