### PR TITLE
Fix failure on manylinux build

### DIFF
--- a/.github/workflows/pypi-manylinux.yml
+++ b/.github/workflows/pypi-manylinux.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel twine
     - name: Build manylinux Python wheels
-      uses: RalfG/python-wheels-manylinux-build@v0.3.1-manylinux2014_x86_64
+      uses: RalfG/python-wheels-manylinux-build@v0.3.3-manylinux2014_x86_64
       with:
         python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38'
         build-requirements: 'cython'


### PR DESCRIPTION
Automatic builds are failing the manylinux build with the following
error:

$ /opt/python/cp37-cp37m/bin/pip install --upgrade --no-cache-dir pip
/opt/_internal/cpython-3.7.9/bin/python3.7: error while loading shared libraries: libcrypt.so.2: cannot open shared object file: No such file or directory

v0.3.2 includes a fix. Updating to the latest.