### PR TITLE
Fix macOS app packaging and related notes

### DIFF
--- a/.github/workflows/buildpackage-mac.yml
+++ b/.github/workflows/buildpackage-mac.yml
@@ -1,4 +1,4 @@
-name: Build Mac OS X app
+name: Build macOS app
 
 on:
   push:
@@ -35,10 +35,12 @@ jobs:
       run: |
         pyi-makespec --hidden-import="pkg_resources.py2_warn" -F --add-data images/\*:images --add-data \*.png:. --add-data \*.ico:. -w -i P-face.icns pronterface.py
         # Edit spec file
+        export git_hash=$(git rev-parse --short "$GITHUB_SHA")
         sed -i '' '$ s/.$//' pronterface.spec
         cat >> pronterface.spec <<EOL
         ,
         info_plist={
+            'CFBundleShortVersionString': '$git_hash',
             'NSPrincipalClass': 'NSApplication',
             'NSAppleScriptEnabled': False,
             'NSAppSleepDisabled': True,
@@ -48,13 +50,11 @@ jobs:
     - name: Make pyinstaller build
       run: |
         pyinstaller --clean pronterface.spec -y
-        ls -l dist/pronterface.app/Contents/macOS/pronterface
-        chmod +x dist/pronterface.app/Contents/macOS/pronterface
-        ls -l dist/pronterface.app/Contents/macOS/pronterface
-        rm dist/pronterface
-        zip -r -X pronterface-app.zip dist
+        # Zip app manually to avoid losing execute permissions for binary file in app
+        cd dist
+        zip -r -X pronterface-app.zip pronterface.app
     - name: Upload artifacts for inspection
       uses: actions/upload-artifact@v2
       with:
         name: macosapp_${{ matrix.os }}_${{ matrix.architecture }}_${{ matrix.python-version }}
-        path: pronterface-app.zip
+        path: dist/pronterface-app.zip

--- a/.github/workflows/buildpackage-mac.yml
+++ b/.github/workflows/buildpackage-mac.yml
@@ -34,6 +34,17 @@ jobs:
     - name: Make pyinstaller spec
       run: |
         pyi-makespec --hidden-import="pkg_resources.py2_warn" -F --add-data images/\*:images --add-data \*.png:. --add-data \*.ico:. -w -i P-face.icns pronterface.py
+        # Edit spec file
+        sed -i '' '$ s/.$//' pronterface.spec
+        cat >> pronterface.spec <<EOL
+        ,
+        info_plist={
+            'NSPrincipalClass': 'NSApplication',
+            'NSAppleScriptEnabled': False,
+            'NSAppSleepDisabled': True,
+          },
+        )
+        EOL
     - name: Make pyinstaller build
       run: |
         pyinstaller --clean pronterface.spec -y

--- a/.github/workflows/buildpackage-mac.yml
+++ b/.github/workflows/buildpackage-mac.yml
@@ -51,6 +51,7 @@ jobs:
         ls -l dist/pronterface.app/Contents/macOS/pronterface
         chmod +x dist/pronterface.app/Contents/macOS/pronterface
         ls -l dist/pronterface.app/Contents/macOS/pronterface
+        rm dist/pronterface
         zip -r -X pronterface-app.zip dist
     - name: Upload artifacts for inspection
       uses: actions/upload-artifact@v2

--- a/.github/workflows/pypi-mac.yml
+++ b/.github/workflows/pypi-mac.yml
@@ -1,4 +1,4 @@
-name: Build Mac OS X Python package
+name: Build macOS Python package
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -16,14 +16,13 @@ If you want the newest, shiniest features, you can run Printrun from source usin
 
 ## Windows
 
-A precompiled version is available at http://koti.kapsi.fi/~kliment/printrun/
+A precompiled version is available at https://github.com/kliment/Printrun/releases
 
-## Mac OS X
+## MacOS
 
-A precompiled version is available at http://koti.kapsi.fi/~kliment/printrun/
+A precompiled version is available at https://github.com/kliment/Printrun/releases
 
-Note for OSX users: if OSX tells you the file is corrupted, you don't need to redownload it. Instead, you need to allow OSX to run unsigned apps. To do this, run 
-`sudo spctl --master-disable`
+Note for OSX users: if OSX tells you `“pronterface.app” cannot be opened because the developer cannot be verified.`, you don't need to redownload it. Instead, you need to allow OSX to run the unsigned app. To do this, right click the application in Finder and select `Open`. Then click `Open` in the popup window that appears. You only need to do this once.
 
 
 ## Linux
@@ -31,15 +30,15 @@ Note for OSX users: if OSX tells you the file is corrupted, you don't need to re
 
 There is currently no package for Printrun 2. It must be [run from source](https://github.com/kliment/Printrun/tree/master#running-from-source).
 
-### Chrome OS 
+### Chrome OS
 
 You can use Printrun via crouton ( https://github.com/dnschneid/crouton ). Assuming you want Ubuntu Trusty, you used probably `sudo sh -e ~/Downloads/crouton -r trusty -t xfce` to install Ubuntu. Fetch and install printrun with the line given above for Ubuntu/Debian.
 
 By default you have no access to the serial port under Chrome OS crouton, so you cannot connect to your 3D printer. Add yourself to the serial group within the linux environment to fix this
 
-`sudo usermod -G serial -a <username>` 
+`sudo usermod -G serial -a <username>`
 
-where `<username>` should be your username. Log out and in to make this group change active and allow communication with your printer. 
+where `<username>` should be your username. Log out and in to make this group change active and allow communication with your printer.
 
 ### Fedora
 
@@ -79,12 +78,12 @@ To use pronterface, you need:
   * numpy (for 3D view)
   * pycairo (to use Projector feature)
   * cairosvg (to use Projector feature)
-  * dbus (to inhibit sleep on some Linux systems) 
+  * dbus (to inhibit sleep on some Linux systems)
 
 ### Use Python virtual environment
 
 Easiest way to run Printrun from source is to create and use a Python [virtual environment](https://docs.python.org/3/tutorial/venv.html).
-The following section assumes Linux. Please see specific instructions for Windows and macOS X below.
+The following section assumes Linux. Please see specific instructions for Windows and macOS below.
 
 **Ubuntu/Debian note:** You might need to install `python3-venv` first.
 
@@ -149,7 +148,7 @@ Download and install [Python 3.6](https://www.python.org/downloads/) and follow 
 ```
 
 
-### macOS X
+### macOS
 
 Install Python 3, you can use Brew:
 
@@ -157,7 +156,17 @@ Install Python 3, you can use Brew:
 $ brew install python3
 ```
 
-And follow the above **Python virtual environment** section. You don't need to search for wxPython wheel, macOS wheels are available from the Python Package Index.
+Then continue to install and set up Printrun:
+
+```console
+$ git clone https://github.com/kliment/Printrun.git  # clone the repository
+$ cd Printrun  # change to Printrun directory
+$ python3 -m venv venv  # create an virtual environment
+$ . venv/bin/activate  # activate the virtual environment (notice the space after the dot)
+(venv) $ python -m pip install -r requirements.txt  # install the rest of dependencies
+# follow instructions for cython gcoder here if desired
+(venv) $ python pronterface.py  # run Pronterface
+```
 
 
 # USING PRINTRUN
@@ -393,7 +402,7 @@ For example, following macro toggles the diagnostic information similarily to th
 
 Macro parameters are available in '!'-escaped python code as locally defined list variable: arg[0] arg[1] ... arg[N]
 
-All python code is executed in the context of the pronsole (or PronterWindow) object, 
+All python code is executed in the context of the pronsole (or PronterWindow) object,
 so it is possible to use all internal variables and methods, which provide great deal of functionality.
 However the internal variables and methods are not very well documented and may be subject of change, as the program is developed.
 Therefore it is best to use pronsole commands, which easily contain majority of the functionality that might be needed.
@@ -401,7 +410,7 @@ Therefore it is best to use pronsole commands, which easily contain majority of 
 Some useful python-mode-only variables:
 
 ```python
-!self.settings - contains all settings, e.g. 
+!self.settings - contains all settings, e.g.
   port (!self.settings.port), baudrate, xy_feedrate, e_feedrate, slicecommand, final_command, build_dimensions
   You can set them also via pronsole command "set", but you can query the values only via python code.
 !self.p - printcore object (see USING PRINTCORE section for using printcore object)
@@ -412,7 +421,7 @@ Some useful python-mode-only variables:
 Some useful methods:
 
 ```python
-!self.onecmd - invokes raw command, e.g. 
+!self.onecmd - invokes raw command, e.g.
     !self.onecmd("move x 10")
     !self.onecmd("!print self.p.loud")
     !self.onecmd("button "+self.cur_button+" fanOFF /C cyan M107")
@@ -484,4 +493,3 @@ along with Printrun.  If not, see <http://www.gnu.org/licenses/>.
 ```
 
 All scripts should contain this license note, if not, feel free to ask us. Please note that files where it is difficult to state this license note (such as images) are distributed under the same terms.
-

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A precompiled version is available at https://github.com/kliment/Printrun/releas
 
 A precompiled version is available at https://github.com/kliment/Printrun/releases
 
-Note for OSX users: if OSX tells you `“pronterface.app” cannot be opened because the developer cannot be verified.`, you don't need to redownload it. Instead, you need to allow OSX to run the unsigned app. To do this, right click the application in Finder and select `Open`. Then click `Open` in the popup window that appears. You only need to do this once.
+Note for OSX users: if OSX tells you `"pronterface.app" cannot be opened because the developer cannot be verified.`, you don't need to redownload it. Instead, you need to allow OSX to run the unsigned app. To do this, right click the application in Finder and select `Open`. Then click `Open` in the popup window that appears. You only need to do this once.
 
 
 ## Linux

--- a/buildinstructions.txt
+++ b/buildinstructions.txt
@@ -19,13 +19,19 @@ python pronterface.py
 
 for packaging:
 pip install pyinstaller
-pyi-makespec -F --add-data images/\*:images --add-data \*.png:. --add-data \*.ico:. -w -i P-face.icns pronterface.py
+pyi-makespec --hidden-import="pkg_resources.py2_warn" -F --add-data images/\*:images --add-data \*.png:. --add-data \*.ico:. -w -i P-face.icns pronterface.py
 rm -rf dist
-pyinstaller --clean pronterface.spec -y
-(edit .plist file to add:
-<key>NSAppSleepDisabled</key>
-<true/>
+sed -i '' '$ s/.$//' pronterface.spec
+cat >> pronterface.spec <<EOL
+,
+info_plist={
+    'NSPrincipalClass': 'NSApplication',
+    'NSAppleScriptEnabled': False,
+    'NSAppSleepDisabled': True,
+  },
 )
+EOL
+pyinstaller --clean pronterface.spec -y
 (optional) codesign -s identityname dist/pronterface.app --deep
 
 setup on windows:
@@ -51,4 +57,3 @@ for packaging:
 pip install pyinstaller
 pyi-makespec -F --add-data images/*;images --add-data *.png;. --add-data *.ico;. -w -i pronterface.ico pronterface.py
 pyinstaller --clean pronterface.spec -y
-

--- a/printrun/utils.py
+++ b/printrun/utils.py
@@ -14,6 +14,7 @@
 # along with Printrun.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import platform
 import sys
 import re
 import gettext
@@ -39,12 +40,20 @@ def install_locale(domain):
     shared_locale_dir = os.path.join(DATADIR, 'locale')
     translation = None
     lang = locale.getdefaultlocale()
+    osPlatform = platform.system()
 
-    if os.path.exists('./locale'):
-        translation = gettext.translation(domain, './locale', languages=[lang[0]], fallback= True)
+    if osPlatform == "Darwin":
+        # improvised workaround for macOS crash with gettext.translation, see issue #1154
+        if os.path.exists(shared_locale_dir): 
+            gettext.install(domain, shared_locale_dir) 
+        else: 
+            gettext.install(domain, './locale') 
     else:
-        translation = gettext.translation(domain, shared_locale_dir, languages=[lang[0]], fallback= True)
-    translation.install()
+        if os.path.exists('./locale'):
+            translation = gettext.translation(domain, './locale', languages=[lang[0]], fallback= True)
+        else:
+            translation = gettext.translation(domain, shared_locale_dir, languages=[lang[0]], fallback= True)
+        translation.install()
 
 class LogFormatter(logging.Formatter):
     def __init__(self, format_default, format_info):


### PR DESCRIPTION
This PR includes changes to the github action script for the macOS build as well as some of the Printrun documentation pertaining to macOS. It's a follow up to #1117. The changes do the following:

Related to build for macOS:
- Enables packaged app to render in full resolution on Retina displays
    - mentioned by me earlier in https://github.com/kliment/Printrun/issues/1117#issuecomment-703063767
    - implemented without committing the `.spec` file in the repository, since @kliment wanted to avoid doing so
- Disables app sleep, which may cause stalled prints
    - there was something about it in `buildinstructions.txt` previously
    - on a previous version of macOS, 10.13 I had to "disable app nap" through finder's "get info" window for the app, thought it might be related to that
- Writes the git commit hash to the version number displayed for the macOS app in Finder
    - this is helpful for debugging since you can't find the precise version anywhere else in the packaged app
- Uploads only the application itself, without an extraneous binary produced by pyinstaller, to cut down the download size
    - noted by @volconst in https://github.com/kliment/Printrun/issues/1069#issuecomment-769948868
- Fixes #1154 with a workaround suggested by @DivingDuck

Related to documentation:
- Amends a troubleshooting suggestion in the README to disable `spctl` to get the app to run. I don't think that's necessary, nor is it a good idea for security reasons.
- Updates the links to precompiled binaries to the Github Releases page