### PR TITLE
Fix poor 3D view interaction behaviour on high-DPI screens

### DIFF
--- a/printrun/gcview.py
+++ b/printrun/gcview.py
@@ -252,7 +252,7 @@ class GcodeViewPanel(wxGLPanel):
                 if delta > 0: self.layerup()
                 else: self.layerdown()
             return
-        x, y = event.GetPosition()
+        x, y = event.GetPosition() * self.GetContentScaleFactor()
         x, y, _ = self.mouse_to_3d(x, y)
         if delta > 0:
             self.zoom(factor, (x, y))

--- a/printrun/gl/panel.py
+++ b/printrun/gl/panel.py
@@ -205,7 +205,7 @@ class wxGLPanel(BASE_CLASS):
 
     def OnReshape(self):
         """Reshape the OpenGL viewport based on the size of the window"""
-        size = self.GetClientSize()
+        size = self.GetClientSize() * self.GetContentScaleFactor()
         oldwidth, oldheight = self.width, self.height
         width, height = size.width, size.height
         if width < 1 or height < 1:
@@ -428,12 +428,13 @@ class wxGLPanel(BASE_CLASS):
         return mulquat(rotz,rota)
 
     def handle_rotation(self, event):
+        content_scale_factor = self.GetContentScaleFactor()
         if self.initpos is None:
-            self.initpos = event.GetPosition()
+            self.initpos = event.GetPosition() * content_scale_factor
         else:
             p1 = self.initpos
-            p2 = event.GetPosition()
-            sz = self.GetClientSize()
+            p2 = event.GetPosition() * content_scale_factor
+            sz = self.GetClientSize() * content_scale_factor
             p1x = p1[0] / (sz[0] / 2) - 1
             p1y = 1 - p1[1] / (sz[1] / 2)
             p2x = p2[0] / (sz[0] / 2) - 1
@@ -447,11 +448,12 @@ class wxGLPanel(BASE_CLASS):
             self.initpos = p2
 
     def handle_translation(self, event):
+        content_scale_factor = self.GetContentScaleFactor()
         if self.initpos is None:
-            self.initpos = event.GetPosition()
+            self.initpos = event.GetPosition() * content_scale_factor
         else:
             p1 = self.initpos
-            p2 = event.GetPosition()
+            p2 = event.GetPosition() * content_scale_factor
             if self.orthographic:
                 x1, y1, _ = self.mouse_to_3d(p1[0], p1[1])
                 x2, y2, _ = self.mouse_to_3d(p2[0], p2[1])


### PR DESCRIPTION
Fixes #1156. In short,

![fix1156](https://user-images.githubusercontent.com/55331709/106582493-e3b6b100-64f8-11eb-8789-c1b5e2e440b2.jpg)

I had to scale all the return values of `event.GetPosition()` and `self.GetClientSize()` by `self.GetContentScaleFactor()`. That's all.

There's only one edge case where the behaviour is still sub-optimal and I don't know how to fix it. It's kind of a niche issue. I have my computer (a mac with a Retina screen) connected to an external display with a lower DPI. When I move the app from one screen to the other, the `width` and `height` attributes of the `wxGLPanel` instance aren't updated for the different DPI because `OnReshape()` doesn't get executed when the window is moved between screens. If there's a way to call this method when that happens it would fix the problem.

If there's no way to do it, it probably isn't a big deal because as soon as the window size is adjusted by the user, `OnReshape()` is called and the DPI correction is applied.