### PR TITLE
wxpython 4.1.0 on macos only, 4.0.x on other platforms

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pyserial (>= 3.0)
-wxPython (== 4.1.0)
+wxPython (>= 4.0.0 , < 4.1.0) ; sys_platform != 'darwin'
+wxPython (== 4.1.0) ; sys_platform == 'darwin'
 numpy (>= 1.8.2)
 pyglet (>= 1.1)
 cffi


### PR DESCRIPTION
Due to the packaging situation on several distros and a bug on windows, bumping wxpython version down to 4.0.x on everything but macos