### PR TITLE
Add a perspective transform option, render gcode views with perspective transform

### DIFF
--- a/printrun/gcview.py
+++ b/printrun/gcview.py
@@ -79,7 +79,9 @@ class GcodeViewPanel(wxGLPanel):
 
     def __init__(self, parent,
                  build_dimensions = (200, 200, 100, 0, 0, 0),
-                 realparent = None, antialias_samples = 0):
+                 realparent = None, antialias_samples = 0, perspective=False):
+        if perspective:
+            self.orthographic=False
         super().__init__(parent, wx.DefaultPosition,
                                              wx.DefaultSize, 0,
                                              antialias_samples = antialias_samples)
@@ -364,11 +366,11 @@ class GcodeViewLoader:
 from printrun.gviz import BaseViz
 class GcodeViewMainWrapper(GcodeViewLoader, BaseViz):
 
-    def __init__(self, parent, build_dimensions, root, circular, antialias_samples, grid):
+    def __init__(self, parent, build_dimensions, root, circular, antialias_samples, grid, perspective=False):
         self.root = root
         self.glpanel = GcodeViewPanel(parent, realparent = self,
                                       build_dimensions = build_dimensions,
-                                      antialias_samples = antialias_samples)
+                                      antialias_samples = antialias_samples, perspective=perspective)
         self.glpanel.SetMinSize((150, 150))
         if self.root and hasattr(self.root, "gcview_color_background"):
             self.glpanel.color_background = self.root.gcview_color_background
@@ -419,7 +421,7 @@ class GcodeViewFrame(GvizBaseFrame, GcodeViewLoader):
                  pos = wx.DefaultPosition, size = wx.DefaultSize,
                  style = wx.DEFAULT_FRAME_STYLE, root = None, circular = False,
                  antialias_samples = 0,
-                 grid = (1, 10)):
+                 grid = (1, 10), perspective=False):
         GvizBaseFrame.__init__(self, parent, ID, title,
                                pos, size, style)
         self.root = root
@@ -441,7 +443,7 @@ class GcodeViewFrame(GvizBaseFrame, GcodeViewLoader):
         self.glpanel = GcodeViewPanel(panel,
                                       build_dimensions = build_dimensions,
                                       realparent = self,
-                                      antialias_samples = antialias_samples)
+                                      antialias_samples = antialias_samples, perspective=perspective)
         vbox.Add(self.glpanel, 1, flag = wx.EXPAND)
 
         self.Bind(wx.EVT_TOOL, lambda x: self.glpanel.zoom_to_center(1.2), id = 1)

--- a/printrun/gui/viz.py
+++ b/printrun/gui/viz.py
@@ -73,7 +73,8 @@ class VizPane(wx.BoxSizer):
                     root = root,
                     circular = root.settings.circular_bed,
                     antialias_samples = int(root.settings.antialias3dsamples),
-                    grid = (root.settings.preview_grid_step1, root.settings.preview_grid_step2))
+                    grid = (root.settings.preview_grid_step1, root.settings.preview_grid_step2),
+                    perspective = root.settings.perspective)
                 root.gviz.clickcb = root.show_viz_window
             except:
                 use2dview = True
@@ -104,7 +105,8 @@ class VizPane(wx.BoxSizer):
                     root = root,
                     circular = root.settings.circular_bed,
                     antialias_samples = int(root.settings.antialias3dsamples),
-                    grid = (root.settings.preview_grid_step1, root.settings.preview_grid_step2))
+                    grid = (root.settings.preview_grid_step1, root.settings.preview_grid_step2),
+                    perspective=root.settings.perspective)
             except:
                 use3dview = False
                 logging.error("3D view mode requested, but we failed to initialize it.\n"

--- a/printrun/pronterface.py
+++ b/printrun/pronterface.py
@@ -969,6 +969,7 @@ Printrun. If not, see <http://www.gnu.org/licenses/>."""
         self.settings._add(BooleanSetting("viz3d", False, _("Use 3D in GCode viewer window"), _("Use 3D mode instead of 2D layered mode in the visualization window"), "Viewer"), self.reload_ui)
         self.settings._add(StaticTextSetting("separator_3d_viewer", _("3D viewer options"), "", group = "Viewer"))
         self.settings._add(BooleanSetting("light3d", False, _("Use a lighter 3D visualization"), _("Use a lighter visualization with simple lines instead of extruded paths for 3D viewer"), "Viewer"), self.reload_ui)
+        self.settings._add(BooleanSetting("perspective", False, _("Use a perspective view instead of orthographic"), _("A perspective view looks more realistic, but is a bit more confusing to navigate"), "Viewer"), self.reload_ui)
         self.settings._add(ComboSetting("antialias3dsamples", "0", ["0", "2", "4", "8"], _("Number of anti-aliasing samples"), _("Amount of anti-aliasing samples used in the 3D viewer"), "Viewer"), self.reload_ui)
         self.settings._add(BooleanSetting("trackcurrentlayer3d", False, _("Track current layer in main 3D view"), _("Track the currently printing layer in the main 3D visualization"), "Viewer"))
         self.settings._add(FloatSpinSetting("gcview_path_width", 0.4, 0.01, 2, _("Extrusion width for 3D viewer"), _("Width of printed path in 3D viewer"), "Viewer", increment = 0.05), self.update_gcview_params)

--- a/printrun/stlview.py
+++ b/printrun/stlview.py
@@ -72,9 +72,12 @@ class StlViewPanel(wxGLPanel):
     def __init__(self, parent, size,
                  build_dimensions = None, circular = False,
                  antialias_samples = 0,
-                 grid = (1, 10)):
+                 grid = (1, 10), perspective=False):
+        if perspective:
+            self.orthographic=False
         super().__init__(parent, wx.DefaultPosition, size, 0,
                                            antialias_samples = antialias_samples)
+        
         self.batches = []
         self.rot = 0
         self.canvas.Bind(wx.EVT_MOUSE_EVENTS, self.move)


### PR DESCRIPTION
When the perspective option in settings->options->viewer is enabled, renders the gcode viewer with a perspective transform instead of an isometric transform. Fixes #1239 