### PR TITLE
Fix missing zoomed_width in perspective mode

### DIFF
--- a/printrun/gl/panel.py
+++ b/printrun/gl/panel.py
@@ -268,14 +268,14 @@ class wxGLPanel(BASE_CLASS):
         glMatrixMode(GL_MODELVIEW)
         glLoadIdentity()
         self.setup_lights()
-        if self.orthographic:
-            wratio = self.width / self.dist
-            hratio = self.height / self.dist
-            minratio = float(min(wratio, hratio))
-            self.zoom_factor = 1.0
-            self.zoomed_width = wratio / minratio
-            self.zoomed_height = hratio / minratio
-            glScalef(factor * minratio, factor * minratio, 1)
+
+        wratio = self.width / self.dist
+        hratio = self.height / self.dist
+        minratio = float(min(wratio, hratio))
+        self.zoom_factor = 1.0
+        self.zoomed_width = wratio / minratio
+        self.zoomed_height = hratio / minratio
+        glScalef(factor * minratio, factor * minratio, 1)
 
     def DrawCanvas(self):
         """Draw the window."""


### PR DESCRIPTION
When Settings->Viewer->Use perspective view is checked, printrun
restated and splitter resized an exception is thrown
AttributeError: 'GcodeViewPanel' object has no attribute 'zoomed_width'
Traceback (most recent call last):
  File "gl/panel.py", line 155, in processSizeEvent
    self.OnReshape()
  File "gl/panel.py", line 235, in OnReshape
    factor = min(wratio * self.zoomed_width, hratio * self.zoomed_height)