### PR TITLE
Only auto-capitalize if first charater is lower-case

### DIFF
--- a/printrun/pronsole.py
+++ b/printrun/pronsole.py
@@ -394,9 +394,11 @@ class pronsole(cmd.Cmd):
     def default(self, l):
         if l[0].upper() in self.commandprefixes.upper():
             if self.p and self.p.online:
+                if l[0] != l[0].upper():
+                    l = l.upper()
                 if not self.p.loud:
-                    self.log("SENDING:" + l.upper())
-                self.p.send_now(l.upper())
+                    self.log("SENDING:" + l)
+                self.p.send_now(l)
             else:
                 self.logError(_("Printer is not online."))
             return


### PR DESCRIPTION
Auto-capitalize commands only if the first character is both a command character and a lower-case one.

This follows the behavior as described by https://github.com/kliment/Printrun/issues/216#issuecomment-18603449.

@frhepo FIY