### PR TITLE
Release Printrun 2.0.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,39 @@
+Printrun - 2.0.0
+====================
+
+Stable release supporting Python 3.10 and wxPython 4.2.
+
+See changes in previous pre-releases below for a full change log from previous
+stable release.
+
+### New Features
+
+ - Dropped support for Windows 32-bit executable (0c296ba)
+ - Added PrintrunGTK3 sub-module. Windows libraries (0c296ba)
+ - CairoSVG >= 2.6.0 not supported (0c296ba)
+ - Port to wxPython 4.2 (0c296ba)
+ - Pyglet >= 2.0 not supported (#1291)
+ - Added option for perspective transformation on gcode rendering (#1240)
+ - Port to Python 3.10 (#1224)
+ - Revised Pronterface graph color configuration (#1206)
+
+### Fixed Bugs
+
+ - Errors on Projector tool (0c296ba)
+ - Errors on Excluder tool (#1307)
+ - Unresponsive GUI (#1303)
+ - Icon/images not found. Wrong paths (#1285)
+ - Error on adjusting speed and flow rate (#1262)
+ - Fixed Armenian translation (#1244, #1245)
+ - Temperature graph empty or missing extruders (#1237)
+ - Princore runSmallScript incorrectly handled comments (#1163)
+
+### Administration
+
+ - Updated Windows and macOS CI/CD procedures
+ - Added CONTRIBUTORS.md to properly credit all the community (#1249)
+
+
 Printrun - 2.0.0rc8
 ====================
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,9 @@ stable release.
 
 ### New Features
 
+ - Windows binaries restricted to Python 3.10 only (#1311)
+ - Improved German translation (#1311)
+ - Updated translation templates (#1311)
  - Dropped support for Windows 32-bit executable (0c296ba)
  - Added PrintrunGTK3 sub-module (0c296ba)
    * Bundled Windows GTK3 libraries for the Projector tool
@@ -20,6 +23,7 @@ stable release.
 
 ### Fixed Bugs
 
+ - Invalid log file path crashed the Windows app (#1300)
  - Errors on Projector tool (0c296ba)
  - Errors on Excluder tool (#1307)
  - Unresponsive GUI (#1303)

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@ stable release.
 
 ### New Features
 
+ - Separate binaries provided for macOS versions 10, 11 and 12 (#1317)
  - Windows binaries restricted to Python 3.10 only (#1311)
  - Improved German translation (#1311)
  - Updated translation templates (#1311)
@@ -33,7 +34,7 @@ stable release.
  - Temperature graph empty or missing extruders (#1237)
  - Princore runSmallScript incorrectly handled comments (#1163)
 
-### Administration
+### Administrative
 
  - Updated Windows and macOS CI/CD procedures
  - Added CONTRIBUTORS.md to properly credit all the community (#1249)

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,8 @@ stable release.
 ### New Features
 
  - Dropped support for Windows 32-bit executable (0c296ba)
- - Added PrintrunGTK3 sub-module. Windows libraries (0c296ba)
+ - Added PrintrunGTK3 sub-module (0c296ba)
+   * Bundled Windows GTK3 libraries for the Projector tool
  - CairoSVG >= 2.6.0 not supported (0c296ba)
  - Port to wxPython 4.2 (0c296ba)
  - Pyglet >= 2.0 not supported (#1291)

--- a/printrun/printcore.py
+++ b/printrun/printcore.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Printrun.  If not, see <http://www.gnu.org/licenses/>.
 
-__version__ = "2.0.0rc8"
+__version__ = "2.0.0"
 
 import sys
 if sys.version_info.major < 3:


### PR DESCRIPTION
Now that #928, #1171 have been dealt with and Windows side has been revamped (many thanks @DivingDuck) I believe we are in shape for finally releasing 2.0.0. Up for debate of course, please speak up if you know any show-stoppers.

Two things I can think of that'd be nice to do before releasing:
 - [x] Test and confirm macOS binaries work as expected
 - [x] Revisit Windows installation instructions and update (if required)

--
Fixes #1305
Fixes #1296
Fixes #1295
Fixes #1252