### PR TITLE
Enable 3D operation for more drivers

### DIFF
--- a/printrun/gl/panel.py
+++ b/printrun/gl/panel.py
@@ -24,6 +24,7 @@ from wx import glcanvas
 
 import pyglet
 pyglet.options['debug_gl'] = True
+pyglet.options['shadow_window'] = False
 
 from pyglet.gl import glEnable, glDisable, GL_LIGHTING, glLightfv, \
     GL_LIGHT0, GL_LIGHT1, GL_LIGHT2, GL_POSITION, GL_DIFFUSE, \


### PR DESCRIPTION
[pyglet documentation (shadow_window)](https://pyglet.readthedocs.io/en/latest/programming_guide/options.html)

Fixes/works around #1313
May need testing whether it negatively affects performance with other drivers (in significant way)

Tested with ~Intel mesa classic~ crocus, llvmpipe and softpipe, under kde x11 and weston with xwayland enabled.