### PR TITLE
p/pronsole: Clean up readline imports

### DIFF
--- a/printrun/pronsole.py
+++ b/printrun/pronsole.py
@@ -49,14 +49,13 @@ if os.name == "nt":
         import winreg
     except:
         pass
+
 READLINE = True
 try:
     import readline
-    try:
-        readline.rl.mode.show_all_if_ambiguous = "on"  # config pyreadline on windows
-    except:
-        pass
-except:
+    if os.name == "nt":   # config pyreadline on Windows
+        readline.rl.mode.show_all_if_ambiguous = "on"
+except ImportError:
     READLINE = False  # neither readline module is available
 
 tempreading_exp = re.compile('\\bT\d*:')
@@ -226,20 +225,16 @@ class pronsole(cmd.Cmd):
 
         self.preloop()
         if self.use_rawinput and self.completekey:
-            try:
-                import readline
-                self.old_completer = readline.get_completer()
-                readline.set_completer(self.complete)
-                readline.parse_and_bind(self.completekey + ": complete")
-                history = (self.history_file)
-                if not os.path.exists(history):
-                    if not os.path.exists(self.cache_dir):
-                        os.makedirs(self.cache_dir)
-                    history = os.path.join(self.cache_dir, "history")
-                if os.path.exists(history):
-                    readline.read_history_file(history)
-            except ImportError:
-                pass
+            self.old_completer = readline.get_completer()
+            readline.set_completer(self.complete)
+            readline.parse_and_bind(self.completekey + ": complete")
+            history = (self.history_file)
+            if not os.path.exists(history):
+                if not os.path.exists(self.cache_dir):
+                    os.makedirs(self.cache_dir)
+                history = os.path.join(self.cache_dir, "history")
+            if os.path.exists(history):
+                readline.read_history_file(history)
         try:
             if intro is not None:
                 self.intro = intro
@@ -273,12 +268,8 @@ class pronsole(cmd.Cmd):
             self.postloop()
         finally:
             if self.use_rawinput and self.completekey:
-                try:
-                    import readline
-                    readline.set_completer(self.old_completer)
-                    readline.write_history_file(self.history_file)
-                except ImportError:
-                    pass
+                readline.set_completer(self.old_completer)
+                readline.write_history_file(self.history_file)
 
     def confirm(self):
         y_or_n = input("y/n: ")


### PR DESCRIPTION
Reviewing issue #1332 made me realize we could clean up the importing of the readline module a bit. Let me know if I got it completely wrong. A quick test on my terminal showed no noticeable change in pronsole's behavior.

Goals:
 * Avoid bare except clauses.
 * Import only once at the top. Because variable 'READLINE' would be set to false, which means 'self.completekey' would be 'None' and these try clauses won't run anyway.

@DivingDuck, please test on Windows and let us know if it breaks anything.