### PR TITLE
exchange of module pyreadline to pyreadline3 (issue #1332)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ lxml (>= 2.9.1)
 appdirs (>= 1.4.0)
 dbus-python >= 1.2.0 ; sys_platform == 'linux'
 pyobjc-framework-Cocoa ; sys_platform == 'darwin'
-pyreadline ; sys_platform == 'win32'
+pyreadline3 ; sys_platform == 'win32'


### PR DESCRIPTION
This PR is to solve issue …/kliment/Printrun/issues/1332. Switching to pyreadline3 should not break the current behavior of Pronterface and Pronsole. 
Successfully Tested on Windows 10 for both, Pronterface and Pronsole.


