### PR TITLE
UXUI Polishing Part 2: Platers, G-Code Viewers, ProjectLayer and SpoolManager

### DIFF
--- a/printrun/excluder.py
+++ b/printrun/excluder.py
@@ -22,22 +22,23 @@ install_locale('pronterface')
 class ExcluderWindow(gviz.GvizWindow):
 
     def __init__(self, excluder, *args, **kwargs):
-        super(ExcluderWindow, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.SetTitle(_("Print Excluder"))
         self.parent = excluder
-       
+
         self.toolbar.ClearTools()
         self.build_toolbar(excluder = True)
         self.toolbar.Realize()
         minsize = self.toolbar.GetEffectiveMinSize().width
         self.SetMinClientSize((minsize, minsize))
         self.p.SetToolTip(
-            "Draw rectangles where print instructions should be ignored.\nExcluder always affects all layers, layer settings is disregarded.")#*
+            _("Draw rectangles where print instructions should be ignored.") +
+            _("\nExcluder always affects all layers, layer setting is disregarded."))
 
         self.p.paint_overlay = self.paint_selection
         self.p.layerup()
 
-        #self.CenterOnParent()
+        self.CenterOnParent()
 
     def real_to_gcode(self, x, y):
         return (x + self.p.build_dimensions[3],
@@ -123,6 +124,7 @@ class Excluder:
         if self.window:
             self.window.Destroy()
             self.window = None
+
 
 if __name__ == '__main__':
     import sys

--- a/printrun/excluder.py
+++ b/printrun/excluder.py
@@ -23,14 +23,21 @@ class ExcluderWindow(gviz.GvizWindow):
 
     def __init__(self, excluder, *args, **kwargs):
         super(ExcluderWindow, self).__init__(*args, **kwargs)
-        self.SetTitle(_("Part excluder: draw rectangles where print instructions should be ignored"))
-        self.toolbar.AddTool(128, " " + _("Reset selection"),
-                             wx.Image(imagefile('reset.png'), wx.BITMAP_TYPE_PNG).ConvertToBitmap(),
-                             _("Reset selection"))
-        self.Bind(wx.EVT_TOOL, self.reset_selection, id = 128)
+        self.SetTitle(_("Print Excluder"))
         self.parent = excluder
+       
+        self.toolbar.ClearTools()
+        self.build_toolbar(excluder = True)
+        self.toolbar.Realize()
+        minsize = self.toolbar.GetEffectiveMinSize().width
+        self.SetMinClientSize((minsize, minsize))
+        self.p.SetToolTip(
+            "Draw rectangles where print instructions should be ignored.\nExcluder always affects all layers, layer settings is disregarded.")#*
+
         self.p.paint_overlay = self.paint_selection
         self.p.layerup()
+
+        #self.CenterOnParent()
 
     def real_to_gcode(self, x, y):
         return (x + self.p.build_dimensions[3],
@@ -96,11 +103,6 @@ class ExcluderWindow(gviz.GvizWindow):
         dc.DrawRectangleList([self._line_scaler(rect)
                               for rect in self.parent.rectangles],
                              None, wx.Brush((200, 200, 200, 150)))
-
-    def reset_selection(self, event):
-        self.parent.rectangles = []
-        wx.CallAfter(self.p.Refresh)
-
 class Excluder:
 
     def __init__(self):

--- a/printrun/gcodeplater.py
+++ b/printrun/gcodeplater.py
@@ -90,6 +90,10 @@ class GcodePlaterPanel(PlaterPanel):
                                         circular = circular_platform,
                                         grid = grid)
         self.platform_object = gcview.GCObject(self.platform)
+        self.Layout()
+        self.SetMinClientSize((self.menupanel.GetEffectiveMinSize().width, 
+                               self.menupanel.GetEffectiveMinSize().height + 48))
+        self.SetTitle("G-Code Plate Builder")
 
     def get_objects(self):
         return [self.platform_object] + list(self.models.values())

--- a/printrun/gcodeplater.py
+++ b/printrun/gcodeplater.py
@@ -82,7 +82,7 @@ class GcodePlaterPanel(PlaterPanel):
                    circular_platform = False,
                    antialias_samples = 0,
                    grid = (1, 10)):
-        super(GcodePlaterPanel, self).prepare_ui(filenames, callback, parent, build_dimensions)
+        super(GcodePlaterPanel, self).prepare_ui(filenames, callback, parent, build_dimensions, cutting_tool = False)
         viewer = gcview.GcodeViewPanel(self, build_dimensions = self.build_dimensions,
                                        antialias_samples = antialias_samples)
         self.set_viewer(viewer)
@@ -91,8 +91,7 @@ class GcodePlaterPanel(PlaterPanel):
                                         grid = grid)
         self.platform_object = gcview.GCObject(self.platform)
         self.Layout()
-        self.SetMinClientSize((self.menupanel.GetEffectiveMinSize().width, 
-                               self.menupanel.GetEffectiveMinSize().height + 48))
+        self.SetMinClientSize(self.topsizer.CalcMin())
         self.SetTitle("G-Code Plate Builder")
 
     def get_objects(self):

--- a/printrun/gcodeplater.py
+++ b/printrun/gcodeplater.py
@@ -101,7 +101,7 @@ class GcodePlaterPanel(PlaterPanel):
     objects = property(get_objects)
 
     def load_file(self, filename):
-        with open(filename, "r", newline = '') as file:
+        with open(filename, "r") as file:
             gcode = gcoder.GCode(file, get_home_pos(self.build_dimensions))
         model = actors.GcodeModel()
         if gcode.filament_length > 0:
@@ -147,7 +147,6 @@ class GcodePlaterPanel(PlaterPanel):
     # but the end goal is to have a clean per-layer merge
     def export_to(self, name):
         return self.export_combined(name)
-        # return self.export_sequential(name)
 
     def export_combined(self, name):
         models = list(self.models.values())
@@ -208,6 +207,10 @@ class GcodePlaterPanel(PlaterPanel):
         logging.info(_("Exported merged G-Codes to %s") % name)
 
     def export_sequential(self, name):
+        '''
+        Initial implementation of the gcode exporter,
+        which prints objects sequentially. No longer used.
+        '''
         models = list(self.models.values())
         last_real_position = None
         # Sort models by Z max to print smaller objects first

--- a/printrun/gui/widgets.py
+++ b/printrun/gui/widgets.py
@@ -17,12 +17,15 @@ import wx
 import re
 import platform
 
-def getSpace(a):
-    # This method is used to de-hardcode and unify the borders and gaps of the interface.
+def get_space(a):
+    '''
+    Takes key (str), returns spacing value (int).
+    Provides correct spacing in pixel for borders and sizers.
+    '''
     match a:
-        case 'major': # e.g. outer border of dialog boxes
+        case 'major':  # e.g. outer border of dialog boxes
             return 12
-        case 'minor': # e.g. border of inner elements
+        case 'minor':  # e.g. border of inner elements
             return 8
         case 'mini':
             return 4
@@ -31,28 +34,25 @@ def getSpace(a):
             platformname = platform.system()
             if platformname == 'Windows':
                 return 8
-            elif platformname == 'Darwin':
+            if platformname == 'Darwin':
                 return 4
-            else:
-                return 4 # Linux systems
+            return 4  # Linux systems
         case 'stddlg-frame':
             # Border for std dialog buttons when used with frames.
             platformname = platform.system()
             if platformname == 'Windows':
                 return 8
-            elif platformname == 'Darwin':
+            if platformname == 'Darwin':
                 return 12
-            else:
-                return 8 # Linux systems
+            return 8  # Linux systems
         case 'staticbox':
             # Border between StaticBoxSizers and the elements inside.
             platformname = platform.system()
             if platformname == 'Windows':
                 return 4
-            elif platformname == 'Darwin':
+            if platformname == 'Darwin':
                 return 0
-            else:
-                return 0 # Linux systems
+            return 0  # Linux systems
         case 'none':
             return 0
 
@@ -80,7 +80,7 @@ class MacroEditor(wx.Dialog):
         self.Bind(wx.EVT_FIND_CLOSE, self.on_find_cancel)
         self.Bind(wx.EVT_CLOSE, self.close)
         titlesizer.Add(self.findbtn, 0, wx.ALIGN_CENTER_VERTICAL)
-        panelsizer.Add(titlesizer, 0, wx.EXPAND | wx.ALL, getSpace('minor'))
+        panelsizer.Add(titlesizer, 0, wx.EXPAND | wx.ALL, get_space('minor'))
         self.e = wx.TextCtrl(panel, style = wx.HSCROLL | wx.TE_MULTILINE | wx.TE_RICH2, size = (400, 400))
         if not self.gcode:
             self.e.SetValue(self.unindent(definition))
@@ -89,9 +89,8 @@ class MacroEditor(wx.Dialog):
         panelsizer.Add(self.e, 1, wx.EXPAND)
         panel.SetSizer(panelsizer)
         topsizer = wx.BoxSizer(wx.VERTICAL)
-        topsizer.Add(panel, 1, wx.EXPAND | wx.ALL, getSpace('none'))
+        topsizer.Add(panel, 1, wx.EXPAND | wx.ALL, get_space('none'))
         # No StaticLine in this case bc the TextCtrl acts as a divider
-        #topsizer.Add(wx.StaticLine(self, -1, style = wx.LI_HORIZONTAL), 0, wx.EXPAND)
         btnsizer = wx.StdDialogButtonSizer()
         self.savebtn = wx.Button(self, wx.ID_SAVE)
         self.savebtn.SetDefault()
@@ -101,9 +100,9 @@ class MacroEditor(wx.Dialog):
         btnsizer.AddButton(self.savebtn)
         btnsizer.AddButton(self.cancelbtn)
         btnsizer.Realize()
-        topsizer.Add(btnsizer, 0, wx.ALIGN_RIGHT | wx.ALL, getSpace('stddlg'))
+        topsizer.Add(btnsizer, 0, wx.ALIGN_RIGHT | wx.ALL, get_space('stddlg'))
         self.SetSizer(topsizer)
-        self.SetMinClientSize((230,150))
+        self.SetMinClientSize((230, 150))  # TODO: Check if self.FromDIP() is needed
         topsizer.Fit(self)
         self.CentreOnParent()
         self.Show()
@@ -112,11 +111,11 @@ class MacroEditor(wx.Dialog):
     def on_find(self, ev):
         # Ask user what to look for, find it and point at it ...  (Jezmy)
         self.findbtn.Disable()
-        self.finddata = wx.FindReplaceData(wx.FR_DOWN)   # initializes and holds search parameters #wx.FR_DOWN
+        self.finddata = wx.FindReplaceData(wx.FR_DOWN)   # initializes and holds search parameters
         selection = self.e.GetStringSelection()
         if selection:
             self.finddata.SetFindString(selection)
-        self.finddialog = wx.FindReplaceDialog(self.e, self.finddata, _("Find..."), wx.FR_NOWHOLEWORD) #wx.FR_REPLACEDIALOG
+        self.finddialog = wx.FindReplaceDialog(self.e, self.finddata, _("Find..."), wx.FR_NOWHOLEWORD)  # wx.FR_REPLACEDIALOG
         # TODO: Setup ReplaceDialog, Setup WholeWord Search, deactivated for now...
         self.finddialog.Show()
 
@@ -124,18 +123,18 @@ class MacroEditor(wx.Dialog):
         self.findbtn.Enable()
         self.titletext.SetLabel("              _")
         self.finddialog.Destroy()
-    
+
     def on_find_find(self, ev):
         findstring = self.finddata.GetFindString()
         macrocode = self.e.GetValue()
-        
+
         if self.e.GetStringSelection().lower() == findstring.lower():
             # If the desired string is already selected, change the position to jump to the next one.
             if self.finddata.GetFlags() % 2 == 1:
                 self.e.SetInsertionPoint(self.e.GetInsertionPoint() + len(findstring))
             else:
                 self.e.SetInsertionPoint(self.e.GetInsertionPoint() - len(findstring))
-        
+
         if int(self.finddata.GetFlags() / 4) != 1:
             # When search is not case-sensitve, convert the whole string to lowercase
             findstring = findstring.casefold()
@@ -146,15 +145,15 @@ class MacroEditor(wx.Dialog):
             stringpos = macrocode.find(findstring, self.e.GetInsertionPoint())
         else:
             stringpos = macrocode.rfind(findstring, 0, self.e.GetInsertionPoint())
-        
+
         if stringpos == -1 and self.finddata.GetFlags() % 2 == 1:
             self.titletext.SetLabel(_("End of macro, jumped to first line"))
-            stringpos = 0 #jump to the beginning
+            stringpos = 0  # jump to the beginning
             self.e.SetInsertionPoint(stringpos)
             self.e.ShowPosition(stringpos)
         elif stringpos == -1 and self.finddata.GetFlags() % 2 == 0:
             self.titletext.SetLabel(_("Begin of macro, jumped to last line"))
-            stringpos = self.e.GetLastPosition() #jump to the end
+            stringpos = self.e.GetLastPosition()  # jump to the end
             self.e.SetInsertionPoint(stringpos)
             self.e.ShowPosition(stringpos)
         else:
@@ -204,6 +203,7 @@ class MacroEditor(wx.Dialog):
                 reindented += self.indent_chars + line + "\n"
         return reindented
 
+
 SETTINGS_GROUPS = {"Printer": _("Printer settings"),
                    "UI": _("User interface"),
                    "Viewer": _("Viewer"),
@@ -234,26 +234,26 @@ class PronterOptionsDialog(wx.Dialog):
             grouppanel.SetScrollRate(fontsize.x, fontsize.y)
             notebook.AddPage(grouppanel, SETTINGS_GROUPS[group])
             settings = groups[group]
-            grid = wx.GridBagSizer(hgap = getSpace('minor'), vgap = getSpace('mini'))
+            grid = wx.GridBagSizer(hgap = get_space('minor'), vgap = get_space('mini'))
             current_row = 0
             # This gives the first entry on the page a tiny bit of extra space to the top
-            grid.Add((12, getSpace('mini')), pos = (current_row, 0), span = (1, 2))
+            grid.Add((12, get_space('mini')), pos = (current_row, 0), span = (1, 2))
             current_row += 1
             for setting in settings:
                 if setting.name.startswith("separator_"):
                     sep = wx.StaticLine(grouppanel, size = (-1, 5), style = wx.LI_HORIZONTAL)
                     grid.Add(sep, pos = (current_row, 0), span = (1, 2),
-                             border = getSpace('mini'), flag = wx.ALIGN_CENTER | wx.ALL | wx.EXPAND)
+                             border = get_space('mini'), flag = wx.ALIGN_CENTER | wx.ALL | wx.EXPAND)
                     current_row += 1
                 label, widget = setting.get_label(grouppanel), setting.get_widget(grouppanel)
                 if setting.name.startswith("separator_"):
                     font = label.GetFont()
                     font.SetWeight(wx.BOLD)
                     label.SetFont(font)
-                grid.Add(label, pos = (current_row, 0), border = getSpace('minor'),
+                grid.Add(label, pos = (current_row, 0), border = get_space('minor'),
                          flag = wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT | wx.LEFT)
                 expand = 0 if isinstance(widget, (wx.SpinCtrlDouble, wx.Choice, wx.ComboBox)) else wx.EXPAND
-                grid.Add(widget, pos = (current_row, 1), border = getSpace('minor'),
+                grid.Add(widget, pos = (current_row, 1), border = get_space('minor'),
                          flag = wx.ALIGN_CENTER_VERTICAL | wx.RIGHT | expand)
                 if hasattr(label, "set_default"):
                     label.Bind(wx.EVT_MOUSE_EVENTS, label.set_default)
@@ -266,12 +266,13 @@ class PronterOptionsDialog(wx.Dialog):
             if group == group_list[0]:
                 grouppanel.SetMinSize(grid.ComputeFittingWindowSize(grouppanel))
         topsizer = wx.BoxSizer(wx.VERTICAL)
-        topsizer.Add(notebook, 1, wx.EXPAND | wx.ALL, getSpace('minor'))
+        topsizer.Add(notebook, 1, wx.EXPAND | wx.ALL, get_space('minor'))
         topsizer.Add(wx.StaticLine(self, -1, style = wx.LI_HORIZONTAL), 0, wx.EXPAND)
-        topsizer.Add(self.CreateButtonSizer(wx.OK | wx.CANCEL), 0, wx.ALIGN_RIGHT | wx.ALL, getSpace('stddlg'))
+        topsizer.Add(self.CreateButtonSizer(wx.OK | wx.CANCEL), 0, wx.ALIGN_RIGHT | wx.ALL, get_space('stddlg'))
         self.SetSizer(topsizer)
         self.Fit()
         self.CentreOnParent()
+
 
 notebookSelection = 0
 def PronterOptions(pronterface):
@@ -297,7 +298,7 @@ class ButtonEdit(wx.Dialog):
                            style = wx.DEFAULT_DIALOG_STYLE)
         self.pronterface = pronterface
         panel = wx.Panel(self)
-        grid = wx.FlexGridSizer(rows = 0, cols = 2, hgap = getSpace('minor'), vgap = getSpace('minor'))
+        grid = wx.FlexGridSizer(rows = 0, cols = 2, hgap = get_space('minor'), vgap = get_space('minor'))
         grid.AddGrowableCol(1, 1)
         ## Title of the button
         grid.Add(wx.StaticText(panel, -1, _("Button title:")), 0, wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
@@ -308,20 +309,20 @@ class ButtonEdit(wx.Dialog):
         ## Colour of the button
         grid.Add(wx.StaticText(panel, -1, _("Colour:")), 0, wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
         coloursizer = wx.BoxSizer(wx.HORIZONTAL)
-        self.use_colour = wx.CheckBox(panel,-1)
-        self.color = wx.ColourPickerCtrl(panel, colour=( 255, 255, 255), style=wx.CLRP_USE_TEXTCTRL)
+        self.use_colour = wx.CheckBox(panel, -1)
+        self.color = wx.ColourPickerCtrl(panel, colour=(255, 255, 255), style=wx.CLRP_USE_TEXTCTRL)
         self.color.Disable()
         self.use_colour.Bind(wx.EVT_CHECKBOX, self.onColourCheckbox)
-        coloursizer.Add(self.use_colour,0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, getSpace('minor'))
+        coloursizer.Add(self.use_colour, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, get_space('minor'))
         coloursizer.Add(self.color, 1, wx.EXPAND)
-        grid.Add(coloursizer,1, wx.EXPAND)
+        grid.Add(coloursizer, 1, wx.EXPAND)
         ## Enter commands or choose a macro
         macrotooltip = _("Type short commands directly, enter a name for a new macro or select an existing macro from the list.")
         commandfield = wx.StaticText(panel, -1, _("Command:"))
         commandfield.SetToolTip(wx.ToolTip(macrotooltip))
         grid.Add(commandfield, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
-        macrochoices = list(self.pronterface.macros.keys()) #add the available macros to the dropdown
-        macrochoices.insert(0,"") #add an empty field, so that a new macro name can be entered
+        macrochoices = list(self.pronterface.macros.keys())  # add the available macros to the dropdown
+        macrochoices.insert(0, "")  # add an empty field, so that a new macro name can be entered
         self.command = wx.ComboBox(panel, -1, "", choices = macrochoices, style = wx.CB_DROPDOWN)
         self.command.SetToolTip(wx.ToolTip(macrotooltip))
         commandsizer = wx.BoxSizer(wx.HORIZONTAL)
@@ -331,13 +332,13 @@ class ButtonEdit(wx.Dialog):
         self.macrobtn.SetMinSize((self.macrobtn.GetTextExtent('AAA').width, -1))
         self.macrobtn.SetToolTip(wx.ToolTip(_("Create a new macro or edit an existing one.")))
         self.macrobtn.Bind(wx.EVT_BUTTON, self.macrob_handler)
-        commandsizer.Add(self.macrobtn, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, getSpace('minor'))
+        commandsizer.Add(self.macrobtn, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, get_space('minor'))
         grid.Add(commandsizer, 1, wx.EXPAND)
         panel.SetSizer(grid)
         topsizer = wx.BoxSizer(wx.VERTICAL)
-        topsizer.Add(panel, 0, wx.EXPAND | wx.ALL, getSpace('major'))
+        topsizer.Add(panel, 0, wx.EXPAND | wx.ALL, get_space('major'))
         topsizer.Add(wx.StaticLine(self, -1, style = wx.LI_HORIZONTAL), 0, wx.EXPAND)
-        topsizer.Add(self.CreateButtonSizer(wx.OK | wx.CANCEL), 0, wx.ALIGN_RIGHT | wx.ALL, getSpace('stddlg'))
+        topsizer.Add(self.CreateButtonSizer(wx.OK | wx.CANCEL), 0, wx.ALIGN_RIGHT | wx.ALL, get_space('stddlg'))
         self.SetSizer(topsizer)
         topsizer.Fit(self)
         self.CentreOnParent()
@@ -413,8 +414,10 @@ class TempGauge(wx.Panel):
         wx.CallAfter(self.Refresh)
 
     def interpolatedColour(self, val, vmin, vmid, vmax, cmin, cmid, cmax):
-        if val < vmin: return cmin
-        if val > vmax: return cmax
+        if val < vmin:
+            return cmin
+        if val > vmax:
+            return cmax
         if val <= vmid:
             lo, hi, val, valhi = cmin, cmid, val - vmin, vmid - vmin
         else:

--- a/printrun/gui/widgets.py
+++ b/printrun/gui/widgets.py
@@ -20,21 +20,39 @@ import platform
 def getSpace(a):
     # This method is used to de-hardcode and unify the borders and gaps of the interface.
     match a:
-        case 'major': #e.g. outer border of dialog boxes
+        case 'major': # e.g. outer border of dialog boxes
             return 12
-        case 'minor': #e.g. border of inner elements
+        case 'minor': # e.g. border of inner elements
             return 8
         case 'mini':
             return 4
         case 'stddlg':
-            # Differentiation is necessary because wxPyhton behaves slightly differently on different systems.
+            # Differentiation is necessary because wxPython behaves slightly differently on different systems.
             platformname = platform.system()
             if platformname == 'Windows':
                 return 8
             elif platformname == 'Darwin':
                 return 4
             else:
-                return 4 # Not sure yet which value should be used for linux systems
+                return 4 # Linux systems
+        case 'stddlg-frame':
+            # Border for std dialog buttons when used with frames.
+            platformname = platform.system()
+            if platformname == 'Windows':
+                return 8
+            elif platformname == 'Darwin':
+                return 12
+            else:
+                return 8 # Linux systems
+        case 'staticbox':
+            # Border between StaticBoxSizers and the elements inside.
+            platformname = platform.system()
+            if platformname == 'Windows':
+                return 4
+            elif platformname == 'Darwin':
+                return 0
+            else:
+                return 0 # Linux systems
         case 'none':
             return 0
 
@@ -63,7 +81,7 @@ class MacroEditor(wx.Dialog):
         self.Bind(wx.EVT_CLOSE, self.close)
         titlesizer.Add(self.findbtn, 0, wx.ALIGN_CENTER_VERTICAL)
         panelsizer.Add(titlesizer, 0, wx.EXPAND | wx.ALL, getSpace('minor'))
-        self.e = wx.TextCtrl(panel, style = wx.HSCROLL | wx.TE_MULTILINE | wx.TE_RICH2, size = (400, 400)) #style = wx.HSCROLL | 
+        self.e = wx.TextCtrl(panel, style = wx.HSCROLL | wx.TE_MULTILINE | wx.TE_RICH2, size = (400, 400))
         if not self.gcode:
             self.e.SetValue(self.unindent(definition))
         else:

--- a/printrun/gviz.py
+++ b/printrun/gviz.py
@@ -586,7 +586,7 @@ class Gviz(wx.Panel, BaseViz):
 if __name__ == '__main__':
     import sys
     app = wx.App(False)
-    with open(sys.argv[1], "r", newline = '') as arg:
+    with open(sys.argv[1], "r") as arg:
         main = GvizWindow(arg)
     main.Show()
     app.MainLoop()

--- a/printrun/gviz.py
+++ b/printrun/gviz.py
@@ -20,7 +20,8 @@ import wx
 import time
 from . import gcoder
 from .injectgcode import injector, injector_edit
-from .gui.widgets import getSpace
+from printrun.gui.viz import BaseViz
+from .gui.widgets import get_space
 
 from .utils import imagefile, install_locale, get_home_pos
 install_locale('pronterface')
@@ -48,8 +49,8 @@ class GvizBaseFrame(wx.Frame):
         return panel, h_sizer
 
     def build_toolbar(self, excluder):
-        self.toolbar.SetMargins(getSpace('minor'), getSpace('mini'))
-        self.toolbar.SetToolPacking(getSpace('minor'))
+        self.toolbar.SetMargins(get_space('minor'), get_space('mini'))
+        self.toolbar.SetToolPacking(get_space('minor'))
         self.toolbar.AddTool(1, '', wx.Image(imagefile('zoom_in.png'), wx.BITMAP_TYPE_PNG).ConvertToBitmap(), _("Zoom In [+]"),)
         self.toolbar.AddTool(2, '', wx.Image(imagefile('zoom_out.png'), wx.BITMAP_TYPE_PNG).ConvertToBitmap(), _("Zoom Out [-]"))
         self.toolbar.AddTool(3, _("Reset View"), wx.Image(imagefile('fit.png'), wx.BITMAP_TYPE_PNG).ConvertToBitmap(), shortHelp = _("Reset View"))
@@ -57,34 +58,36 @@ class GvizBaseFrame(wx.Frame):
         self.toolbar.AddTool(4, '', wx.Image(imagefile('arrow_up.png'), wx.BITMAP_TYPE_PNG).ConvertToBitmap(), _("Move Up a Layer [U]"))
         self.toolbar.AddTool(5, '', wx.Image(imagefile('arrow_down.png'), wx.BITMAP_TYPE_PNG).ConvertToBitmap(), _("Move Down a Layer [D]"))
         self.toolbar.AddSeparator()
-        if not excluder: # This is added to the 'GCode Viewer' Toolbar
-            self.toolbar.AddTool(6, 'Inject', wx.Image(imagefile('inject.png'), wx.BITMAP_TYPE_PNG).ConvertToBitmap(), wx.NullBitmap, shortHelp = _("Inject G-Code"), longHelp = _("Insert code at the beginning of this layer"))
-            self.toolbar.AddTool(7, 'Edit', wx.Image(imagefile('edit.png'), wx.BITMAP_TYPE_PNG).ConvertToBitmap(), wx.NullBitmap, shortHelp = _("Edit Layer"), longHelp = _("Edit the G-Code of this layer"))
-        else: # This is added to the 'Excluder' Toolbar
+        if not excluder:  # This is added to the 'GCode Viewer' Toolbar
+            self.toolbar.AddTool(6, 'Inject', wx.Image(imagefile('inject.png'), wx.BITMAP_TYPE_PNG).ConvertToBitmap(),
+                                 wx.NullBitmap, shortHelp = _("Inject G-Code"), longHelp = _("Insert code at the beginning of this layer"))
+            self.toolbar.AddTool(7, 'Edit', wx.Image(imagefile('edit.png'), wx.BITMAP_TYPE_PNG).ConvertToBitmap(),
+                                 wx.NullBitmap, shortHelp = _("Edit Layer"), longHelp = _("Edit the G-Code of this layer"))
+        else:  # This is added to the 'Excluder' Toolbar
             self.toolbar.AddTool(8, _('Reset Selection'), wx.Image(imagefile('reset.png'), wx.BITMAP_TYPE_PNG).ConvertToBitmap(), shortHelp = _("Reset Selection"))
         self.toolbar.AddStretchableSpace()
         self.toolbar.AddSeparator()
-        #self.toolbar.AddTool(10, _('Help'), wx.Image(imagefile('fit.png'), wx.BITMAP_TYPE_PNG).ConvertToBitmap(), shortHelp = _("Quick Info Panel"))
         self.toolbar.AddTool(9, _('Close'), wx.Image(imagefile('fit.png'), wx.BITMAP_TYPE_PNG).ConvertToBitmap(), shortHelp = _("Close Window"))
-   
+
     def setlayercb(self, layer):
         self.layerslider.SetValue(layer)
 
     def process_slider(self, event):
         raise NotImplementedError
 
+
 ID_ABOUT = 101
 ID_EXIT = 110
 class GvizWindow(GvizBaseFrame):
     def __init__(self, f = None, size = (550, 550), build_dimensions = [200, 200, 100, 0, 0, 0], grid = (10, 50), extrusion_width = 0.5, bgcolor = "#000000"):
-        super(GvizWindow, self).__init__(None, title = _("GCode Viewer"), size = size, style = wx.DEFAULT_FRAME_STYLE)
+        super().__init__(None, title = _("GCode Viewer"), size = size, style = wx.DEFAULT_FRAME_STYLE)
 
         panel, h_sizer = self.create_base_ui()
 
         self.p = Gviz(panel, size = size, build_dimensions = build_dimensions, grid = grid, extrusion_width = extrusion_width, bgcolor = bgcolor, realparent = self)
         h_sizer.Add(self.p, 1, wx.EXPAND)
-        h_sizer.Add(self.layerslider, 0, wx.EXPAND | wx.ALL, getSpace('minor'))
-        self.p.SetToolTip("Shift to move view, mousewheel to set layer")#*
+        h_sizer.Add(self.layerslider, 0, wx.EXPAND | wx.ALL, get_space('minor'))
+        self.p.SetToolTip("Shift + Click to move view, scroll to change layer")
 
         self.Layout()
         size = (size[0] + self.layerslider.GetEffectiveMinSize().width,
@@ -172,13 +175,17 @@ class GvizWindow(GvizBaseFrame):
     def zoom(self, event):
         z = event.GetWheelRotation()
         if event.ShiftDown():
-            if z > 0: self.p.layerdown()
-            elif z < 0: self.p.layerup()
+            if z > 0:
+                self.p.layerdown()
+            elif z < 0:
+                self.p.layerup()
         else:
-            if z > 0: self.p.zoom(event.GetX(), event.GetY(), 1.2)
-            elif z < 0: self.p.zoom(event.GetX(), event.GetY(), 1 / 1.2)
+            if z > 0:
+                self.p.zoom(event.GetX(), event.GetY(), 1.2)
+            elif z < 0:
+                self.p.zoom(event.GetX(), event.GetY(), 1 / 1.2)
 
-from printrun.gui.viz import BaseViz
+
 class Gviz(wx.Panel, BaseViz):
 
     # Mark canvas as dirty when setting showall
@@ -225,7 +232,7 @@ class Gviz(wx.Panel, BaseViz):
         self.bgcolor.Set(bgcolor)
         self.blitmap = wx.Bitmap(self.GetClientSize()[0], self.GetClientSize()[1], -1)
         self.paint_overlay = None
-  
+
     def inject(self):
         layer = self.layers[self.layerindex]
         injector(self.gcode, self.layerindex, layer)
@@ -340,9 +347,9 @@ class Gviz(wx.Panel, BaseViz):
     def _drawarcs(self, dc, arcs, pens):
         scaled_arcs = [self._arc_scaler(a) for a in arcs]
         dc.SetBrush(wx.TRANSPARENT_BRUSH)
-        for i in range(len(scaled_arcs)):
+        for i, arc in enumerate(scaled_arcs):
             dc.SetPen(pens[i] if isinstance(pens, numpy.ndarray) else pens)
-            dc.DrawArc(*scaled_arcs[i])
+            dc.DrawArc(*arc)
 
     def repaint_everything(self):
         width = self.scale[0] * self.build_dimensions[0]
@@ -462,25 +469,25 @@ class Gviz(wx.Panel, BaseViz):
         target = start_pos[:]
         target[5] = 0.0
         target[6] = 0.0
-        if gline.current_x is not None: target[0] = gline.current_x
-        if gline.current_y is not None: target[1] = gline.current_y
-        if gline.current_z is not None: target[2] = gline.current_z
+        if gline.current_x is not None:
+            target[0] = gline.current_x
+        if gline.current_y is not None:
+            target[1] = gline.current_y
+        if gline.current_z is not None:
+            target[2] = gline.current_z
         if gline.e is not None:
             if gline.relative_e:
                 target[3] += gline.e
             else:
                 target[3] = gline.e
-        if gline.f is not None: target[4] = gline.f
-        if gline.i is not None: target[5] = gline.i
-        if gline.j is not None: target[6] = gline.j
+        if gline.f is not None:
+            target[4] = gline.f
+        if gline.i is not None:
+            target[5] = gline.i
+        if gline.j is not None:
+            target[6] = gline.j
 
-        if gline.command in ["G0", "G1"]:
-            line = [self._x(start_pos[0]),
-                    self._y(start_pos[1]),
-                    self._x(target[0]),
-                    self._y(target[1])]
-            return target, line, None
-        elif gline.command in ["G2", "G3"]:
+        if gline.command in ["G2", "G3"]:
             # startpos, endpos, arc center
             arc = [self._x(start_pos[0]), self._y(start_pos[1]),
                    self._x(target[0]), self._y(target[1]),
@@ -488,6 +495,13 @@ class Gviz(wx.Panel, BaseViz):
             if gline.command == "G2":  # clockwise, reverse endpoints
                 arc[0], arc[1], arc[2], arc[3] = arc[2], arc[3], arc[0], arc[1]
             return target, None, arc
+
+        # ["G0", "G1"]:
+        line = [self._x(start_pos[0]),
+                self._y(start_pos[1]),
+                self._x(target[0]),
+                self._y(target[1])]
+        return target, line, None
 
     def _y(self, y):
         return self.build_dimensions[1] - (y - self.build_dimensions[4])
@@ -568,9 +582,11 @@ class Gviz(wx.Panel, BaseViz):
         self.hilightpos = target
         wx.CallAfter(self.Refresh)
 
+
 if __name__ == '__main__':
     import sys
     app = wx.App(False)
-    main = GvizWindow(open(sys.argv[1], "rU"))
+    with open(sys.argv[1], "r", newline = '') as arg:
+        main = GvizWindow(arg)
     main.Show()
     app.MainLoop()

--- a/printrun/objectplater.py
+++ b/printrun/objectplater.py
@@ -37,82 +37,113 @@ class PlaterPanel(wx.Panel):
         super().__init__(parent = parent)
         self.prepare_ui(**kwargs)
 
-    def prepare_ui(self, filenames = [], callback = None, parent = None, build_dimensions = None):
+    def prepare_ui(self, filenames = [], callback = None, parent = None, build_dimensions = None, cutting_tool = True):
         self.filenames = filenames
-        panel = self.menupanel = wx.Panel(self)
-        grid = self.menusizer = wx.GridBagSizer(vgap = getSpace('mini'), hgap = getSpace('mini'))
-        list_sizer = wx.StaticBoxSizer(wx.VERTICAL, panel, label = "Models")
+        
+        menu_sizer = self.menu_sizer = wx.BoxSizer(wx.VERTICAL)
+        
+        list_sizer = wx.StaticBoxSizer(wx.VERTICAL, self, label = "Models")
         # Load button
-        loadbutton = wx.Button(panel, label = _("+ Add Model"))
+        loadbutton = wx.Button(self, label = _("+ Add Model"))
         loadbutton.Bind(wx.EVT_BUTTON, self.load)
         list_sizer.Add(loadbutton,  0, wx.EXPAND | wx.BOTTOM, getSpace('mini'))
         # Model list
-        self.l = wx.ListBox(panel)
+        self.l = wx.ListBox(self)
         list_sizer.Add(self.l,  1, wx.EXPAND | wx.BOTTOM, getSpace('mini'))
         # Auto arrange button
-        self.autobutton = wx.Button(panel, label = _("Auto Arrange"))
+        self.autobutton = wx.Button(self, label = _("Auto Arrange"))
         self.autobutton.Bind(wx.EVT_BUTTON, self.autoplate)
         self.autobutton.Disable()
-        list_sizer.Add(self.autobutton,  0, wx.EXPAND | wx.BOTTOM, getSpace('minor'))
+        list_sizer.Add(self.autobutton,  0, wx.EXPAND | wx.BOTTOM, getSpace('mini'))
         h_sizer = wx.BoxSizer(wx.HORIZONTAL)
         # Clear button
-        self.clearbutton = wx.Button(panel, label = _("Clear All"))
+        self.clearbutton = wx.Button(self, label = _("Clear All"))
         self.clearbutton.Bind(wx.EVT_BUTTON, self.clear)
         self.clearbutton.Disable()
-        h_sizer.Add(self.clearbutton,  1, wx.EXPAND | wx.RIGHT, getSpace('minor'))
+        h_sizer.Add(self.clearbutton,  1, wx.EXPAND | wx.RIGHT, getSpace('mini'))
         # Export button
-        self.exportbutton = wx.Button(panel, label = _("Export"))
+        self.exportbutton = wx.Button(self, label = _("Export"))
         self.exportbutton.Bind(wx.EVT_BUTTON, self.export)
         self.exportbutton.Disable()
         h_sizer.Add(self.exportbutton,  1, wx.EXPAND)
         list_sizer.Add(h_sizer,  0, wx.EXPAND)
 
-        grid.Add(list_sizer, pos = (0, 0), span = (1, 1), 
-                 flag = wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, border = getSpace('mini'))
-        grid.AddGrowableRow(0)
-
-        selection_sizer = wx.StaticBoxSizer(wx.VERTICAL, panel, label = "Selection")
+        selection_sizer = wx.StaticBoxSizer(wx.VERTICAL, self, label = "Selection")
         # Snap to Z = 0 button
-        self.snapbutton = wx.Button(panel, label = _("Snap to Zero"))
+        self.snapbutton = wx.Button(self, label = _("Snap to Zero"))
         self.snapbutton.Bind(wx.EVT_BUTTON, self.snap)
         self.snapbutton.Disable()
         h2_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        h2_sizer.Add(self.snapbutton,  1, wx.EXPAND | wx.RIGHT, getSpace('minor'))
+        h2_sizer.Add(self.snapbutton,  1, wx.EXPAND | wx.RIGHT, getSpace('mini'))
         # Put at center button
-        self.centerbutton = wx.Button(panel, label = _("Put at Center"))
+        self.centerbutton = wx.Button(self, label = _("Put at Center"))
         self.centerbutton.Bind(wx.EVT_BUTTON, self.center)
         self.centerbutton.Disable()
         h2_sizer.Add(self.centerbutton,  1, wx.EXPAND)
-        selection_sizer.Add(h2_sizer,  0, wx.EXPAND | wx.BOTTOM, getSpace('minor'))
+        selection_sizer.Add(h2_sizer,  0, wx.EXPAND | wx.BOTTOM, getSpace('mini'))
         # Delete button
-        self.deletebutton = wx.Button(panel, label = _("Delete"))
+        self.deletebutton = wx.Button(self, label = _("Delete"))
         self.deletebutton.Bind(wx.EVT_BUTTON, self.delete)
         self.deletebutton.Disable()
         selection_sizer.Add(self.deletebutton,  0, wx.EXPAND | wx.ALL, getSpace('none'))
-        
-        grid.Add(selection_sizer, pos = (1, 0), span = (1, 1), 
-                 flag = wx.EXPAND | wx.ALL, border = getSpace('mini'))
 
+        menu_sizer.Add(list_sizer, 1, wx.EXPAND | wx.ALL, getSpace('minor'))
+        menu_sizer.Add(selection_sizer, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, getSpace('minor'))
+
+        if cutting_tool == True:
+            # Insert Cutting tool (only for STL Plater)
+            cut_sizer = wx.StaticBoxSizer(wx.VERTICAL, self, label = _("Cutting Tool"))
+            ## Prepare buttons for all cut axis
+            axis_sizer = self.axis_sizer = wx.BoxSizer(wx.HORIZONTAL)
+            cutxplusbutton = wx.ToggleButton(self, label = _("+X"), style = wx.BU_EXACTFIT)
+            cutxplusbutton.Bind(wx.EVT_TOGGLEBUTTON, lambda event: self.start_cutting_tool(event, "x", 1))
+            axis_sizer.Add(cutxplusbutton, 1, wx.EXPAND | wx.RIGHT, getSpace('mini'))
+            cutyplusbutton = wx.ToggleButton(self, label = _("+Y"), style = wx.BU_EXACTFIT)
+            cutyplusbutton.Bind(wx.EVT_TOGGLEBUTTON, lambda event: self.start_cutting_tool(event, "y", 1))
+            axis_sizer.Add(cutyplusbutton, 1, wx.EXPAND | wx.RIGHT, getSpace('mini'))
+            cutzplusbutton = wx.ToggleButton(self, label = _("+Z"), style = wx.BU_EXACTFIT)
+            cutzplusbutton.Bind(wx.EVT_TOGGLEBUTTON, lambda event: self.start_cutting_tool(event, "z", 1))
+            axis_sizer.Add(cutzplusbutton, 1, wx.EXPAND | wx.RIGHT, getSpace('mini'))
+            cutxminusbutton = wx.ToggleButton(self, label = _("-X"), style = wx.BU_EXACTFIT)
+            cutxminusbutton.Bind(wx.EVT_TOGGLEBUTTON, lambda event: self.start_cutting_tool(event, "x", -1))
+            axis_sizer.Add(cutxminusbutton, 1, wx.EXPAND | wx.RIGHT, getSpace('mini'))
+            cutyminusbutton = wx.ToggleButton(self, label = _("-Y"), style = wx.BU_EXACTFIT)
+            cutyminusbutton.Bind(wx.EVT_TOGGLEBUTTON, lambda event: self.start_cutting_tool(event, "y", -1))
+            axis_sizer.Add(cutyminusbutton, 1, wx.EXPAND | wx.RIGHT, getSpace('mini'))
+            cutzminusbutton = wx.ToggleButton(self, label = _("-Z"), style = wx.BU_EXACTFIT)
+            cutzminusbutton.Bind(wx.EVT_TOGGLEBUTTON, lambda event: self.start_cutting_tool(event, "z", -1))
+            axis_sizer.Add(cutzminusbutton, 1, flag = wx.EXPAND)
+
+            cut_sizer.Add(wx.StaticText(self, -1, _("Choose axis to cut along:")), 0, wx.BOTTOM, getSpace('mini'))
+            cut_sizer.Add(axis_sizer, 0, wx.EXPAND, wx.BOTTOM, getSpace('minor'))
+            cut_sizer.Add(wx.StaticText(self, -1, _("Doubleclick to set the cutting plane.")), 0, wx.TOP | wx.BOTTOM, getSpace('mini'))
+            # Process cut button
+            cut_processbutton = self.cut_processbutton = wx.Button(self, label = _("Process Cut"))
+            cut_processbutton.Bind(wx.EVT_BUTTON, lambda event: self.cut_confirm(event))
+            cut_sizer.Add(cut_processbutton, 0, flag = wx.EXPAND)
+
+            menu_sizer.Add(cut_sizer, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, getSpace('minor'))
+        
         self.basedir = "."
-        self.models = {}
-        panel.SetSizer(grid)      
-        self.topsizer = wx.BoxSizer(wx.VERTICAL)
-        self.topsizer.Add(panel, -1, wx.EXPAND)
-        self.topsizer.Add(wx.StaticLine(self, -1, style = wx.LI_HORIZONTAL), 0, wx.EXPAND)
+        self.models = {}   
+        self.topsizer = wx.GridBagSizer(vgap = 0, hgap = 0)
+        self.topsizer.Add(menu_sizer, pos = (0, 0), span = (1, 1), flag = wx.EXPAND)
+        self.topsizer.Add(wx.StaticLine(self, -1, style = wx.LI_HORIZONTAL), pos = (1, 0), span = (1, 2), flag = wx.EXPAND)
         
         if callback is not None:
-            self.topsizer.Add(self.CreateButtonSizer(wx.OK | wx.CANCEL), 0, wx.ALIGN_RIGHT | wx.ALL, getSpace('stddlg'))
+            self.topsizer.Add(self.CreateButtonSizer(wx.OK | wx.CANCEL), pos = (2, 0), span = (1, 2), 
+                              flag = wx.ALIGN_RIGHT | wx.ALL, border = getSpace('stddlg'))
             self.Bind(wx.EVT_BUTTON, lambda e: self.done(e, callback), id=wx.ID_OK)
             self.Bind(wx.EVT_BUTTON, lambda e: self.Destroy(), id=wx.ID_CANCEL)
 
+        self.topsizer.AddGrowableRow(0)
+        self.topsizer.AddGrowableCol(1)
         self.SetSizer(self.topsizer)
         self.build_dimensions = build_dimensions or [200, 200, 100, 0, 0, 0]
 
     def set_viewer(self, viewer):
-        print("debug: set_viewer patch")
         # Patch handle_rotation on the fly
         if hasattr(viewer, "handle_rotation"):
-            print("debug: handle_rot")
             def handle_rotation(self, event, orig_handler):
                 if self.initpos is None:
                     self.initpos = event.GetPosition()
@@ -129,7 +160,6 @@ class PlaterPanel(wx.Panel):
             patch_method(viewer, "handle_rotation", handle_rotation)
         # Patch handle_wheel on the fly
         if hasattr(viewer, "handle_wheel"):
-            print("debug: handle_wheel")
             def handle_wheel(self, event, orig_handler):
                 if event.ShiftDown():
                     angle = 10
@@ -141,9 +171,7 @@ class PlaterPanel(wx.Panel):
             patch_method(viewer, "handle_wheel", handle_wheel)
         self.s = viewer
         self.s.SetMinSize((150, 150))
-        nrows = self.menusizer.GetRows()
-        self.menusizer.Add(self.s, pos = (0, 1), span = (nrows, 1), flag = wx.EXPAND)
-        self.menusizer.AddGrowableCol(1)
+        self.topsizer.Add(self.s, pos = (0, 1), span = (1, 1), flag = wx.EXPAND)
 
     def move_shape(self, delta):
         """moves shape (selected in l, which is list ListBox of shapes)

--- a/printrun/objectplater.py
+++ b/printrun/objectplater.py
@@ -73,7 +73,7 @@ class PlaterPanel(wx.Panel):
 
         selection_sizer = wx.StaticBoxSizer(wx.VERTICAL, panel, label = "Selection")
         # Snap to Z = 0 button
-        self.snapbutton = wx.Button(panel, label = _("Snap to Z = 0"))
+        self.snapbutton = wx.Button(panel, label = _("Snap to Zero"))
         self.snapbutton.Bind(wx.EVT_BUTTON, self.snap)
         self.snapbutton.Disable()
         h2_sizer = wx.BoxSizer(wx.HORIZONTAL)
@@ -91,7 +91,7 @@ class PlaterPanel(wx.Panel):
         selection_sizer.Add(self.deletebutton,  0, wx.EXPAND | wx.ALL, getSpace('none'))
         
         grid.Add(selection_sizer, pos = (1, 0), span = (1, 1), 
-                 flag = wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, border = getSpace('mini'))
+                 flag = wx.EXPAND | wx.ALL, border = getSpace('mini'))
 
         self.basedir = "."
         self.models = {}
@@ -109,8 +109,10 @@ class PlaterPanel(wx.Panel):
         self.build_dimensions = build_dimensions or [200, 200, 100, 0, 0, 0]
 
     def set_viewer(self, viewer):
+        print("debug: set_viewer patch")
         # Patch handle_rotation on the fly
         if hasattr(viewer, "handle_rotation"):
+            print("debug: handle_rot")
             def handle_rotation(self, event, orig_handler):
                 if self.initpos is None:
                     self.initpos = event.GetPosition()
@@ -127,6 +129,7 @@ class PlaterPanel(wx.Panel):
             patch_method(viewer, "handle_rotation", handle_rotation)
         # Patch handle_wheel on the fly
         if hasattr(viewer, "handle_wheel"):
+            print("debug: handle_wheel")
             def handle_wheel(self, event, orig_handler):
                 if event.ShiftDown():
                     angle = 10
@@ -240,6 +243,7 @@ class PlaterPanel(wx.Panel):
             self.Refresh()
 
     def enable_buttons(self, value):
+            # A little helper method to give the user a cue which tools are available
             self.autobutton.Enable(value)
             self.clearbutton.Enable(value)
             self.exportbutton.Enable(value)

--- a/printrun/objectplater.py
+++ b/printrun/objectplater.py
@@ -13,14 +13,14 @@
 # You should have received a copy of the GNU General Public License
 # along with Printrun.  If not, see <http://www.gnu.org/licenses/>.
 
-from .utils import install_locale, iconfile
-install_locale('pronterface')
-
 import logging
 import os
 import types
 import wx
-from .gui.widgets import getSpace
+from .gui.widgets import get_space
+
+from .utils import install_locale, iconfile
+install_locale('pronterface')
 
 def patch_method(obj, method, replacement):
     orig_handler = getattr(obj, method)
@@ -39,100 +39,98 @@ class PlaterPanel(wx.Panel):
 
     def prepare_ui(self, filenames = [], callback = None, parent = None, build_dimensions = None, cutting_tool = True):
         self.filenames = filenames
-        
+        self.cut_axis_buttons = []
+
         menu_sizer = self.menu_sizer = wx.BoxSizer(wx.VERTICAL)
-        
         list_sizer = wx.StaticBoxSizer(wx.VERTICAL, self, label = "Models")
         # Load button
         loadbutton = wx.Button(self, label = _("+ Add Model"))
         loadbutton.Bind(wx.EVT_BUTTON, self.load)
-        list_sizer.Add(loadbutton,  0, wx.EXPAND | wx.BOTTOM, getSpace('mini'))
+        list_sizer.Add(loadbutton, 0, wx.EXPAND | wx.BOTTOM, get_space('mini'))
         # Model list
         self.l = wx.ListBox(self)
-        list_sizer.Add(self.l,  1, wx.EXPAND | wx.BOTTOM, getSpace('mini'))
+        list_sizer.Add(self.l, 1, wx.EXPAND | wx.BOTTOM, get_space('mini'))
         # Auto arrange button
-        self.autobutton = wx.Button(self, label = _("Auto Arrange"))
-        self.autobutton.Bind(wx.EVT_BUTTON, self.autoplate)
-        self.autobutton.Disable()
-        list_sizer.Add(self.autobutton,  0, wx.EXPAND | wx.BOTTOM, getSpace('mini'))
+        autobutton = wx.Button(self, label = _("Auto Arrange"))
+        autobutton.Bind(wx.EVT_BUTTON, self.autoplate)
+        list_sizer.Add(autobutton, 0, wx.EXPAND | wx.BOTTOM, get_space('mini'))
         h_sizer = wx.BoxSizer(wx.HORIZONTAL)
         # Clear button
-        self.clearbutton = wx.Button(self, label = _("Clear All"))
-        self.clearbutton.Bind(wx.EVT_BUTTON, self.clear)
-        self.clearbutton.Disable()
-        h_sizer.Add(self.clearbutton,  1, wx.EXPAND | wx.RIGHT, getSpace('mini'))
+        clearbutton = wx.Button(self, label = _("Clear All"))
+        clearbutton.Bind(wx.EVT_BUTTON, self.clear)
+        h_sizer.Add(clearbutton, 1, wx.EXPAND | wx.RIGHT, get_space('mini'))
         # Export button
-        self.exportbutton = wx.Button(self, label = _("Export"))
-        self.exportbutton.Bind(wx.EVT_BUTTON, self.export)
-        self.exportbutton.Disable()
-        h_sizer.Add(self.exportbutton,  1, wx.EXPAND)
-        list_sizer.Add(h_sizer,  0, wx.EXPAND)
+        exportbutton = wx.Button(self, label = _("Export"))
+        exportbutton.Bind(wx.EVT_BUTTON, self.export)
+        h_sizer.Add(exportbutton, 1, wx.EXPAND)
+        list_sizer.Add(h_sizer, 0, wx.EXPAND)
 
         selection_sizer = wx.StaticBoxSizer(wx.VERTICAL, self, label = "Selection")
         # Snap to Z = 0 button
-        self.snapbutton = wx.Button(self, label = _("Snap to Zero"))
-        self.snapbutton.Bind(wx.EVT_BUTTON, self.snap)
-        self.snapbutton.Disable()
+        snapbutton = wx.Button(self, label = _("Snap to Zero"))
+        snapbutton.Bind(wx.EVT_BUTTON, self.snap)
         h2_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        h2_sizer.Add(self.snapbutton,  1, wx.EXPAND | wx.RIGHT, getSpace('mini'))
+        h2_sizer.Add(snapbutton, 1, wx.EXPAND | wx.RIGHT, get_space('mini'))
         # Put at center button
-        self.centerbutton = wx.Button(self, label = _("Put at Center"))
-        self.centerbutton.Bind(wx.EVT_BUTTON, self.center)
-        self.centerbutton.Disable()
-        h2_sizer.Add(self.centerbutton,  1, wx.EXPAND)
-        selection_sizer.Add(h2_sizer,  0, wx.EXPAND | wx.BOTTOM, getSpace('mini'))
+        centerbutton = wx.Button(self, label = _("Put at Center"))
+        centerbutton.Bind(wx.EVT_BUTTON, self.center)
+        h2_sizer.Add(centerbutton, 1, wx.EXPAND)
+        selection_sizer.Add(h2_sizer, 0, wx.EXPAND | wx.BOTTOM, get_space('mini'))
         # Delete button
-        self.deletebutton = wx.Button(self, label = _("Delete"))
-        self.deletebutton.Bind(wx.EVT_BUTTON, self.delete)
-        self.deletebutton.Disable()
-        selection_sizer.Add(self.deletebutton,  0, wx.EXPAND | wx.ALL, getSpace('none'))
+        deletebutton = wx.Button(self, label = _("Delete"))
+        deletebutton.Bind(wx.EVT_BUTTON, self.delete)
+        selection_sizer.Add(deletebutton, 0, wx.EXPAND | wx.ALL, get_space('none'))
 
-        menu_sizer.Add(list_sizer, 1, wx.EXPAND | wx.ALL, getSpace('minor'))
-        menu_sizer.Add(selection_sizer, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, getSpace('minor'))
+        menu_sizer.Add(list_sizer, 1, wx.EXPAND | wx.ALL, get_space('minor'))
+        menu_sizer.Add(selection_sizer, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, get_space('minor'))
+        self.menu_buttons = [autobutton, clearbutton, exportbutton, snapbutton, centerbutton, deletebutton]
 
-        if cutting_tool == True:
+        if cutting_tool:
             # Insert Cutting tool (only for STL Plater)
             cut_sizer = wx.StaticBoxSizer(wx.VERTICAL, self, label = _("Cutting Tool"))
-            ## Prepare buttons for all cut axis
+            # Prepare buttons for all cut axis
             axis_sizer = self.axis_sizer = wx.BoxSizer(wx.HORIZONTAL)
             cutxplusbutton = wx.ToggleButton(self, label = _("+X"), style = wx.BU_EXACTFIT)
             cutxplusbutton.Bind(wx.EVT_TOGGLEBUTTON, lambda event: self.start_cutting_tool(event, "x", 1))
-            axis_sizer.Add(cutxplusbutton, 1, wx.EXPAND | wx.RIGHT, getSpace('mini'))
+            axis_sizer.Add(cutxplusbutton, 1, wx.EXPAND | wx.RIGHT, get_space('mini'))
             cutyplusbutton = wx.ToggleButton(self, label = _("+Y"), style = wx.BU_EXACTFIT)
             cutyplusbutton.Bind(wx.EVT_TOGGLEBUTTON, lambda event: self.start_cutting_tool(event, "y", 1))
-            axis_sizer.Add(cutyplusbutton, 1, wx.EXPAND | wx.RIGHT, getSpace('mini'))
+            axis_sizer.Add(cutyplusbutton, 1, wx.EXPAND | wx.RIGHT, get_space('mini'))
             cutzplusbutton = wx.ToggleButton(self, label = _("+Z"), style = wx.BU_EXACTFIT)
             cutzplusbutton.Bind(wx.EVT_TOGGLEBUTTON, lambda event: self.start_cutting_tool(event, "z", 1))
-            axis_sizer.Add(cutzplusbutton, 1, wx.EXPAND | wx.RIGHT, getSpace('mini'))
+            axis_sizer.Add(cutzplusbutton, 1, wx.EXPAND | wx.RIGHT, get_space('mini'))
             cutxminusbutton = wx.ToggleButton(self, label = _("-X"), style = wx.BU_EXACTFIT)
             cutxminusbutton.Bind(wx.EVT_TOGGLEBUTTON, lambda event: self.start_cutting_tool(event, "x", -1))
-            axis_sizer.Add(cutxminusbutton, 1, wx.EXPAND | wx.RIGHT, getSpace('mini'))
+            axis_sizer.Add(cutxminusbutton, 1, wx.EXPAND | wx.RIGHT, get_space('mini'))
             cutyminusbutton = wx.ToggleButton(self, label = _("-Y"), style = wx.BU_EXACTFIT)
             cutyminusbutton.Bind(wx.EVT_TOGGLEBUTTON, lambda event: self.start_cutting_tool(event, "y", -1))
-            axis_sizer.Add(cutyminusbutton, 1, wx.EXPAND | wx.RIGHT, getSpace('mini'))
+            axis_sizer.Add(cutyminusbutton, 1, wx.EXPAND | wx.RIGHT, get_space('mini'))
             cutzminusbutton = wx.ToggleButton(self, label = _("-Z"), style = wx.BU_EXACTFIT)
             cutzminusbutton.Bind(wx.EVT_TOGGLEBUTTON, lambda event: self.start_cutting_tool(event, "z", -1))
             axis_sizer.Add(cutzminusbutton, 1, flag = wx.EXPAND)
+            self.cut_axis_buttons = [cutxplusbutton, cutyplusbutton, cutzplusbutton,
+                                     cutxminusbutton, cutyminusbutton, cutzminusbutton]
 
-            cut_sizer.Add(wx.StaticText(self, -1, _("Choose axis to cut along:")), 0, wx.BOTTOM, getSpace('mini'))
-            cut_sizer.Add(axis_sizer, 0, wx.EXPAND, wx.BOTTOM, getSpace('minor'))
-            cut_sizer.Add(wx.StaticText(self, -1, _("Doubleclick to set the cutting plane.")), 0, wx.TOP | wx.BOTTOM, getSpace('mini'))
+            cut_sizer.Add(wx.StaticText(self, -1, _("Choose axis to cut along:")), 0, wx.BOTTOM, get_space('mini'))
+            cut_sizer.Add(axis_sizer, 0, wx.EXPAND, wx.BOTTOM, get_space('minor'))
+            cut_sizer.Add(wx.StaticText(self, -1, _("Doubleclick to set the cutting plane.")), 0, wx.TOP | wx.BOTTOM, get_space('mini'))
             # Process cut button
-            cut_processbutton = self.cut_processbutton = wx.Button(self, label = _("Process Cut"))
-            cut_processbutton.Bind(wx.EVT_BUTTON, lambda event: self.cut_confirm(event))
-            cut_sizer.Add(cut_processbutton, 0, flag = wx.EXPAND)
+            self.cut_processbutton = wx.Button(self, label = _("Process Cut"))
+            self.cut_processbutton.Bind(wx.EVT_BUTTON, lambda event: self.cut_confirm(event))
+            cut_sizer.Add(self.cut_processbutton, 0, flag = wx.EXPAND)
+            menu_sizer.Add(cut_sizer, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, get_space('minor'))
+            self.enable_cut_button(False)
 
-            menu_sizer.Add(cut_sizer, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, getSpace('minor'))
-        
+        self.enable_buttons(False)  # While no file is loaded all buttons are disabled
         self.basedir = "."
-        self.models = {}   
+        self.models = {}
         self.topsizer = wx.GridBagSizer(vgap = 0, hgap = 0)
         self.topsizer.Add(menu_sizer, pos = (0, 0), span = (1, 1), flag = wx.EXPAND)
         self.topsizer.Add(wx.StaticLine(self, -1, style = wx.LI_HORIZONTAL), pos = (1, 0), span = (1, 2), flag = wx.EXPAND)
-        
+
         if callback is not None:
-            self.topsizer.Add(self.CreateButtonSizer(wx.OK | wx.CANCEL), pos = (2, 0), span = (1, 2), 
-                              flag = wx.ALIGN_RIGHT | wx.ALL, border = getSpace('stddlg'))
+            self.topsizer.Add(self.CreateButtonSizer(wx.OK | wx.CANCEL), pos = (2, 0), span = (1, 2),
+                              flag = wx.ALIGN_RIGHT | wx.ALL, border = get_space('stddlg'))
             self.Bind(wx.EVT_BUTTON, lambda e: self.done(e, callback), id=wx.ID_OK)
             self.Bind(wx.EVT_BUTTON, lambda e: self.Destroy(), id=wx.ID_CANCEL)
 
@@ -200,6 +198,7 @@ class PlaterPanel(wx.Panel):
         name = self.l.GetString(name)
         model = self.models[name]
         model.rot += angle
+        return True
 
     def autoplate(self, event = None):
         logging.info(_("Autoplating"))
@@ -207,9 +206,9 @@ class PlaterPanel(wx.Panel):
         try:
             from printrun import packer
             p = packer.Packer()
-            for i in self.models:
-                width = abs(self.models[i].dims[0] - self.models[i].dims[1])
-                height = abs(self.models[i].dims[2] - self.models[i].dims[3])
+            for i, model in self.models.items():
+                width = abs(model.dims[0] - model.dims[1])
+                height = abs(model.dims[2] - model.dims[3])
                 p.add_rect(width, height, data = i)
             centerx = self.build_dimensions[0] / 2 + self.build_dimensions[3]
             centery = self.build_dimensions[1] / 2 + self.build_dimensions[4]
@@ -225,13 +224,13 @@ class PlaterPanel(wx.Panel):
             cursor = [0, 0, 0]
             newrow = 0
             max = [0, 0]
-            for i in self.models:
-                self.models[i].offsets[2] = -1.0 * self.models[i].dims[4]
-                x = abs(self.models[i].dims[0] - self.models[i].dims[1])
-                y = abs(self.models[i].dims[2] - self.models[i].dims[3])
+            for i, model in self.models.items():
+                model.offsets[2] = -1.0 * model.dims[4]
+                x = abs(model.dims[0] - model.dims[1])
+                y = abs(model.dims[2] - model.dims[3])
                 centre = [x / 2, y / 2]
-                centreoffset = [self.models[i].dims[0] + centre[0],
-                                self.models[i].dims[2] + centre[1]]
+                centreoffset = [model.dims[0] + centre[0],
+                                model.dims[2] + centre[1]]
                 if (cursor[0] + x + separation) >= bedsize[0]:
                     cursor[0] = 0
                     cursor[1] += newrow + separation
@@ -241,8 +240,8 @@ class PlaterPanel(wx.Panel):
                 # To the person who works out why the offsets are applied
                 # differently here:
                 #    Good job, it confused the hell out of me.
-                self.models[i].offsets[0] = cursor[0] + centre[0] - centreoffset[0]
-                self.models[i].offsets[1] = cursor[1] + centre[1] - centreoffset[1]
+                model.offsets[0] = cursor[0] + centre[0] - centreoffset[0]
+                model.offsets[1] = cursor[1] + centre[1] - centreoffset[1]
                 if (max[0] == 0) or (max[0] < (cursor[0] + x)):
                     max[0] = cursor[0] + x
                 if (max[1] == 0) or (max[1] < (cursor[1] + x)):
@@ -255,9 +254,9 @@ class PlaterPanel(wx.Panel):
             centerx = self.build_dimensions[0] / 2 + self.build_dimensions[3]
             centery = self.build_dimensions[1] / 2 + self.build_dimensions[4]
             centreoffset = [centerx - max[0] / 2, centery - max[1] / 2]
-            for i in self.models:
-                self.models[i].offsets[0] += centreoffset[0]
-                self.models[i].offsets[1] += centreoffset[1]
+            for i, model in self.models.items():
+                model.offsets[0] += centreoffset[0]
+                model.offsets[1] += centreoffset[1]
         self.Refresh()
 
     def clear(self, event):
@@ -268,16 +267,25 @@ class PlaterPanel(wx.Panel):
             self.models = {}
             self.l.Clear()
             self.enable_buttons(False)
+            if self.cut_axis_buttons:
+                self.enable_cut_button(False)
             self.Refresh()
 
     def enable_buttons(self, value):
-            # A little helper method to give the user a cue which tools are available
-            self.autobutton.Enable(value)
-            self.clearbutton.Enable(value)
-            self.exportbutton.Enable(value)
-            self.snapbutton.Enable(value)
-            self.deletebutton.Enable(value)
-            self.centerbutton.Enable(value)
+        # A helper method to give the user a cue which tools are available
+        for button in self.menu_buttons:
+            button.Enable(value)
+
+        if self.cut_axis_buttons:  # Only STL Plater has cut axis buttons
+            for button in self.cut_axis_buttons:
+                button.SetValue(False)
+                button.Enable(value)
+
+        self.Refresh()
+
+    def enable_cut_button(self, value):
+        self.cut_processbutton.Enable(value)
+        self.Refresh()
 
     def center(self, event):
         i = self.l.GetSelection()
@@ -303,6 +311,8 @@ class PlaterPanel(wx.Panel):
             self.l.Select(self.l.GetCount() - 1)
             if self.l.GetCount() < 1:
                 self.enable_buttons(False)
+                if self.cut_axis_buttons:
+                    self.enable_cut_button(False)
             self.Refresh()
 
     def add_model(self, name, model):
@@ -354,7 +364,7 @@ class Plater(wx.Dialog):
         size = kwargs.get("size", (800, 580))
         if "size" in kwargs:
             del kwargs["size"]
-        wx.Dialog.__init__(self, parent, title = _("STL Plate Builder"), 
+        wx.Dialog.__init__(self, parent, title = _("STL Plate Builder"),
                            size = size, style = wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER)
         self.SetIcon(wx.Icon(iconfile("plater.png"), wx.BITMAP_TYPE_PNG))
         self.prepare_ui(**kwargs)

--- a/printrun/projectlayer.py
+++ b/printrun/projectlayer.py
@@ -319,7 +319,9 @@ class SettingsFrame(wx.Dialog):
         fieldsizer.Add(wx.StaticText(settingsGroup, -1, _("Direction:")), pos = (4, 0), flag = wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
         self.direction = wx.Choice(settingsGroup, -1, choices = [_('Top Down'), _('Bottom Up')], size = (125, -1))
         saved_direction = self._get_setting('project_direction', 0)
-        if not saved_direction.isdigit(): # This setting used to be a string, so older settings need to be overwritten
+        try:
+            int(saved_direction) # This setting used to be a string, so older settings need to be overwritten
+        except:    
             saved_direction = 0
             self._set_setting('project_direction', saved_direction)
         self.direction.SetSelection(int(saved_direction))

--- a/printrun/projectlayer.py
+++ b/printrun/projectlayer.py
@@ -28,6 +28,9 @@ import re
 from collections import OrderedDict
 import math
 from printrun.gui.widgets import get_space
+from .utils import install_locale
+install_locale('pronterface')
+# Set up Internationalization using gettext
 
 class DisplayFrame(wx.Frame):
     def __init__(self, parent, title, res = (1024, 768), printer = None, scale = 1.0, offset = (0, 0)):
@@ -644,9 +647,9 @@ class SettingsFrame(wx.Dialog):
                 layerHeight = float(self.thickness.GetValue())
             else:
                 layers = self.parse_svg(name)
-                layerHeight = float(f"{layers[1]:.3f}")
+                layerHeight = round(layers[1], 3)
                 self.thickness.SetValue(str(layerHeight))
-                self.statusbar.SetLabel(_("Layer thickness detected: {0:.2f} mm").format(layerHeight))
+                self.statusbar.SetLabel(_("Layer thickness detected: {0} mm").format(layerHeight))
             self.statusbar.SetLabel(_("{0} layers found, total height {1:.2f} mm").format(len(layers[0]), layerHeight * len(layers[0])))
             self.layers = layers
             self.set_total_layers(len(layers[0]))

--- a/printrun/projectlayer.py
+++ b/printrun/projectlayer.py
@@ -48,7 +48,8 @@ class DisplayFrame(wx.Frame):
         self.SetBackgroundColour("black")
         self.pic.Hide()
         self.SetDoubleBuffered(True)
-        self.SetPosition((self.control_frame.GetSize().x, 0))
+        #self.SetPosition((self.control_frame.GetSize().x, 0))
+        self.CentreOnParent()
         self.Show()
 
         self.scale = scale
@@ -461,7 +462,8 @@ class SettingsFrame(wx.Frame):
         bs.Add(self.panel, flag=wx.EXPAND)
         self.SetSizerAndFit(bs)
         self.Fit()
-        self.SetPosition((0, 0))
+        #self.SetPosition((0, 0))
+        self.CentreOnParent()
         self.Show()
 
     def __del__(self):

--- a/printrun/projectlayer.py
+++ b/printrun/projectlayer.py
@@ -792,7 +792,7 @@ class SettingsFrame(wx.Dialog):
         pause = self.pause.GetValue()
 
         if ',' in pause:
-            self.statusbar.SetLabel(_("'Blank' contains a comma, please HHHHHHHHHHHHHHHHHHHHuse a point for decimal values."))
+            self.statusbar.SetLabel(_("'Blank' contains a comma, please use a point for decimal values."))
             self.Layout() # Layout() is needed to ellipsize possible overlength status
             return False
 

--- a/printrun/projectlayer.py
+++ b/printrun/projectlayer.py
@@ -28,6 +28,7 @@ import copy
 import re
 from collections import OrderedDict
 import math
+from printrun.gui.widgets import getSpace
 
 class DisplayFrame(wx.Frame):
     def __init__(self, parent, title, res = (1024, 768), printer = None, scale = 1.0, offset = (0, 0)):
@@ -48,7 +49,7 @@ class DisplayFrame(wx.Frame):
         self.SetBackgroundColour("black")
         self.pic.Hide()
         self.SetDoubleBuffered(True)
-        #self.SetPosition((self.control_frame.GetSize().x, 0))
+        #self.SetPosition((self.control_frame.GetSize().x / 2, 24))
         self.CentreOnParent()
         self.Show()
 
@@ -105,7 +106,7 @@ class DisplayFrame(wx.Frame):
                 pngbytes = PNGSurface.convert(dpi = self.dpi, bytestring = xml.etree.ElementTree.tostring(image))
                 pngImage = wx.Image(io.BytesIO(pngbytes))
 
-                #print("w:", pngImage.Width, ", dpi:", self.dpi, ", w (mm): ",(pngImage.Width / self.dpi) * 25.4)
+                #self.statusbar.SetLabel("w:", pngImage.Width, ", dpi:", self.dpi, ", w (mm): ",(pngImage.Width / self.dpi) * 25.4)
 
                 if self.layer_red:
                     pngImage = pngImage.AdjustChannels(1, 0, 0, 1)
@@ -119,10 +120,10 @@ class DisplayFrame(wx.Frame):
                     image = wx.Image(image)
                 if self.layer_red:
                     image = image.AdjustChannels(1, 0, 0, 1)
-                bitmap = wx.Bitmap(image.Scale(image.Width * self.scale, image.Height * self.scale))
-                dc.DrawBitmap(bitmap, self.offset[0], -self.offset[1], True)
+                bitmap = wx.Bitmap(image.Scale(int(image.Width * self.scale), int(image.Height * self.scale))) #*
+                dc.DrawBitmap(bitmap, int(self.offset[0]), int(-self.offset[1]), True)
             else:
-                raise Exception(self.slicer + " is an unknown method.")
+                raise Exception(self.slicer + _(" is an unknown method."))
 
             self.pic.SetBitmap(self.bitmap)
             self.pic.Show()
@@ -133,7 +134,7 @@ class DisplayFrame(wx.Frame):
             pass
 
     def show_img_delay(self, image):
-        print("Showing", str(time.perf_counter()))
+        self.Parent.statusbar.SetLabel(_("Showing, Timestamp %s s") % str(time.perf_counter()))
         self.control_frame.set_current_layer(self.index)
         self.draw_layer(image)
         # AGe 2022-07-31 Python 3.10 and CallLater expects delay in millyseconds as 
@@ -141,10 +142,10 @@ class DisplayFrame(wx.Frame):
         wx.CallLater(int(1000 * self.interval), self.hide_pic_and_rise)
 
     def rise(self):
-        if self.direction == "Top Down":
-            print("Lowering", str(time.perf_counter()))
-        else:
-            print("Rising", str(time.perf_counter()))
+        if self.direction == 0: # 0: Top Down
+            self.Parent.statusbar.SetLabel(_("Lowering, Timestamp %s s") % str(time.perf_counter()))
+        else: # self.direction == 1, 1: Bottom Up
+            self.Parent.statusbar.SetLabel(_("Rising, Timestamp %s s") % str(time.perf_counter()))
 
         if self.printer is not None and self.printer.online:
             self.printer.send_now("G91")
@@ -154,10 +155,10 @@ class DisplayFrame(wx.Frame):
                     if line:
                         self.printer.send_now(line)
 
-            if self.direction == "Top Down":
+            if self.direction == 0: # 0: Top Down
                 self.printer.send_now("G1 Z-%f F%g" % (self.overshoot, self.z_axis_rate,))
                 self.printer.send_now("G1 Z%f F%g" % (self.overshoot - self.thickness, self.z_axis_rate,))
-            else:  # self.direction == "Bottom Up"
+            else: # self.direction == 1, 1: Bottom Up
                 self.printer.send_now("G1 Z%f F%g" % (self.overshoot, self.z_axis_rate,))
                 self.printer.send_now("G1 Z-%f F%g" % (self.overshoot - self.thickness, self.z_axis_rate,))
 
@@ -170,11 +171,11 @@ class DisplayFrame(wx.Frame):
         else:
             time.sleep(self.pause)
 
-        # AGe 2022-07-31 Python 3.10 expects delay in millyseconds as integer value instead of float. Convert float value to int
+        # AGe 2022-07-31 Python 3.10 expects delay in milliseconds as integer value instead of float. Convert float value to int
         wx.CallLater(int(1000 * self.pause), self.next_img)
 
     def hide_pic(self):
-        print("Hiding", str(time.perf_counter()))
+        self.Parent.statusbar.SetLabel(_("Hiding, Timestamp %s s") % str(time.perf_counter()))
         self.pic.Hide()
 
     def hide_pic_and_rise(self):
@@ -185,11 +186,11 @@ class DisplayFrame(wx.Frame):
         if not self.running:
             return
         if self.index < len(self.layers):
-            print(self.index)
+            self.Parent.statusbar.SetLabel(str(self.index))
             wx.CallAfter(self.show_img_delay, self.layers[self.index])
             self.index += 1
         else:
-            print("end")
+            self.Parent.statusbar.SetLabel(_("End"))
             wx.CallAfter(self.pic.Hide)
             wx.CallAfter(self.Refresh)
 
@@ -201,7 +202,7 @@ class DisplayFrame(wx.Frame):
                 z_axis_rate = 200,
                 prelift_gcode = "",
                 postlift_gcode = "",
-                direction = "Top Down",
+                direction = 0, # 0: Top Down
                 thickness = 0.4,
                 scale = 1,
                 size = (1024, 768),
@@ -227,7 +228,7 @@ class DisplayFrame(wx.Frame):
 
         self.next_img()
 
-class SettingsFrame(wx.Frame):
+class SettingsFrame(wx.Dialog):
 
     def _set_setting(self, name, value):
         if self.pronterface:
@@ -243,9 +244,9 @@ class SettingsFrame(wx.Frame):
             return val
 
     def __init__(self, parent, printer = None):
-        wx.Frame.__init__(self, parent, title = "ProjectLayer Control", style = (wx.DEFAULT_FRAME_STYLE | wx.WS_EX_CONTEXTHELP))
+        wx.Dialog.__init__(self, parent, title = _("ProjectLayer Control"), style = (wx.DEFAULT_DIALOG_STYLE | wx.DIALOG_EX_CONTEXTHELP))
         self.pronterface = parent
-        self.display_frame = DisplayFrame(self, title = "ProjectLayer Display", printer = printer)
+        self.display_frame = DisplayFrame(self, title = _("ProjectLayer Display"), printer = printer)
 
         self.panel = wx.Panel(self)
 
@@ -256,211 +257,240 @@ class SettingsFrame(wx.Frame):
             self.Unbind(wx.EVT_ACTIVATE, handler=fit)
         self.Bind(wx.EVT_ACTIVATE, fit)
 
-        buttonGroup = wx.StaticBox(self.panel, label = "Controls")
+        buttonGroup = wx.StaticBox(self.panel, label = _("Controls"))
         buttonbox = wx.StaticBoxSizer(buttonGroup, wx.HORIZONTAL)
 
-        load_button = wx.Button(buttonGroup, -1, "Load")
+        load_button = wx.Button(buttonGroup, -1, _("Load"))
         load_button.Bind(wx.EVT_BUTTON, self.load_file)
-        load_button.SetToolTip("Choose an SVG file created from Slic3r or Skeinforge, or a zip file of bitmap images (with extension: .3dlp.zip).")
-        buttonbox.Add(load_button, flag = wx.LEFT | wx.RIGHT | wx.BOTTOM, border = 5)
+        load_button.SetToolTip(_("Choose an SVG file created from Slic3r or Skeinforge, or a zip file of bitmap images (with extension: .3dlp.zip)."))
+        buttonbox.Add(load_button, 1, flag = wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, border = getSpace('mini'))
 
-        present_button = wx.Button(buttonGroup, -1, "Present")
-        present_button.Bind(wx.EVT_BUTTON, self.start_present)
-        present_button.SetToolTip("Starts the presentation of the slices.")
-        buttonbox.Add(present_button, flag = wx.LEFT | wx.RIGHT | wx.BOTTOM, border = 5)
+        self.present_button = wx.Button(buttonGroup, -1, _("Start"))
+        self.present_button.Bind(wx.EVT_BUTTON, self.start_present)
+        self.present_button.SetToolTip(_("Starts the presentation of the slices."))
+        buttonbox.Add(self.present_button, 1, flag = wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, border = getSpace('mini'))
+        self.present_button.Disable()
 
-        self.pause_button = wx.Button(buttonGroup, -1, "Pause")
+        self.pause_button = wx.Button(buttonGroup, -1, self.getButtonLabel('pause'))
         self.pause_button.Bind(wx.EVT_BUTTON, self.pause_present)
-        self.pause_button.SetToolTip("Pauses the presentation. Can be resumed afterwards by clicking this button, or restarted by clicking present again.")
-        buttonbox.Add(self.pause_button, flag = wx.LEFT | wx.RIGHT | wx.BOTTOM, border = 5)
+        self.pause_button.SetToolTip(_("Pauses the presentation. Can be resumed afterwards by clicking this button, or restarted by clicking present again."))
+        buttonbox.Add(self.pause_button, 1, flag = wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, border = getSpace('mini'))
+        self.pause_button.Disable()
 
-        stop_button = wx.Button(buttonGroup, -1, "Stop")
-        stop_button.Bind(wx.EVT_BUTTON, self.stop_present)
-        stop_button.SetToolTip("Stops presenting the slices.")
-        buttonbox.Add(stop_button, flag = wx.LEFT | wx.RIGHT | wx.BOTTOM, border = 5)
+        self.stop_button = wx.Button(buttonGroup, -1, _("Stop"))
+        self.stop_button.Bind(wx.EVT_BUTTON, self.stop_present)
+        self.stop_button.SetToolTip(_("Stops presenting the slices."))
+        buttonbox.Add(self.stop_button, 1, flag = wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, border = getSpace('mini'))
+        self.stop_button.Disable()
 
-        settingsGroup = wx.StaticBox(self.panel, label = "Settings")
+        settingsGroup = wx.StaticBox(self.panel, label = _("Settings"))
         fieldboxsizer = wx.StaticBoxSizer(settingsGroup, wx.VERTICAL)
-        fieldsizer = wx.GridBagSizer(10, 10)
+        fieldsizer = wx.GridBagSizer(vgap = getSpace('minor'), hgap = getSpace('minor'))
 
         # Left Column
 
-        fieldsizer.Add(wx.StaticText(settingsGroup, -1, "Layer (mm):"), pos = (0, 0), flag = wx.ALIGN_CENTER_VERTICAL)
+        fieldsizer.Add(wx.StaticText(settingsGroup, -1, _("Layer (mm):")), pos = (0, 0), flag = wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
         self.thickness = wx.TextCtrl(settingsGroup, -1, str(self._get_setting("project_layer", "0.1")), size = (125, -1))
         self.thickness.Bind(wx.EVT_TEXT, self.update_thickness)
-        self.thickness.SetToolTip("The thickness of each slice. Should match the value used to slice the model.  SVG files update this value automatically, 3dlp.zip files have to be manually entered.")
+        self.thickness.SetToolTip(_("The thickness of each slice. Should match the value used to slice the model.  SVG files update this value automatically, 3dlp.zip files have to be manually entered."))
         fieldsizer.Add(self.thickness, pos = (0, 1))
 
-        fieldsizer.Add(wx.StaticText(settingsGroup, -1, "Exposure (s):"), pos = (1, 0), flag = wx.ALIGN_CENTER_VERTICAL)
+        fieldsizer.Add(wx.StaticText(settingsGroup, -1, _("Exposure (s):")), pos = (1, 0), flag = wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
         self.interval = wx.TextCtrl(settingsGroup, -1, str(self._get_setting("project_interval", "0.5")), size = (125, -1))
         self.interval.Bind(wx.EVT_TEXT, self.update_interval)
-        self.interval.SetToolTip("How long each slice should be displayed.")
+        self.interval.SetToolTip(_("How long each slice should be displayed."))
         fieldsizer.Add(self.interval, pos = (1, 1))
 
-        fieldsizer.Add(wx.StaticText(settingsGroup, -1, "Blank (s):"), pos = (2, 0), flag = wx.ALIGN_CENTER_VERTICAL)
+        fieldsizer.Add(wx.StaticText(settingsGroup, -1, _("Blank (s):")), pos = (2, 0), flag = wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
         self.pause = wx.TextCtrl(settingsGroup, -1, str(self._get_setting("project_pause", "0.5")), size = (125, -1))
         self.pause.Bind(wx.EVT_TEXT, self.update_pause)
-        self.pause.SetToolTip("The pause length between slices. This should take into account any movement of the Z axis, plus time to prepare the resin surface (sliding, tilting, sweeping, etc).")
+        self.pause.SetToolTip(_("The pause length between slices. This should take into account any movement of the Z axis, plus time to prepare the resin surface (sliding, tilting, sweeping, etc)."))
         fieldsizer.Add(self.pause, pos = (2, 1))
 
-        fieldsizer.Add(wx.StaticText(settingsGroup, -1, "Scale:"), pos = (3, 0), flag = wx.ALIGN_CENTER_VERTICAL)
+        fieldsizer.Add(wx.StaticText(settingsGroup, -1, _("Scale:")), pos = (3, 0), flag = wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
         self.scale = wx.SpinCtrlDouble(settingsGroup, -1, initial = self._get_setting('project_scale', 1.0), inc = 0.1, size = (125, -1))
         self.scale.SetDigits(3)
         self.scale.Bind(wx.EVT_SPINCTRLDOUBLE, self.update_scale)
-        self.scale.SetToolTip("The additional scaling of each slice.")
+        self.scale.SetToolTip(_("The additional scaling of each slice."))
         fieldsizer.Add(self.scale, pos = (3, 1))
 
-        fieldsizer.Add(wx.StaticText(settingsGroup, -1, "Direction:"), pos = (4, 0), flag = wx.ALIGN_CENTER_VERTICAL)
-        self.direction = wx.ComboBox(settingsGroup, -1, choices = ["Top Down", "Bottom Up"], value = self._get_setting('project_direction', "Top Down"), size = (125, -1))
-        self.direction.Bind(wx.EVT_COMBOBOX, self.update_direction)
-        self.direction.SetToolTip("The direction the Z axis should move. Top Down is where the projector is above the model, Bottom up is where the projector is below the model.")
+        fieldsizer.Add(wx.StaticText(settingsGroup, -1, _("Direction:")), pos = (4, 0), flag = wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
+        #self.direction = wx.ComboBox(settingsGroup, -1, choices = ['Top Down', 'Bottom Up'], value = self._get_setting('project_direction', 'Top Down'), size = (125, -1), style = wx.CB_READONLY)
+        self.direction = wx.Choice(settingsGroup, -1, choices = [_('Top Down'), _('Bottom Up')], size = (125, -1))
+        saved_direction = self._get_setting('project_direction', 0)
+        if not saved_direction.isdigit(): # This setting used to be a string, so older settings need to be overwritten
+            saved_direction = 0
+            self._set_setting('project_direction', saved_direction)
+        self.direction.SetSelection(int(saved_direction))
+        self.direction.Bind(wx.EVT_CHOICE, self.update_direction)
+        self.direction.SetToolTip(_("The direction the Z axis should move. Top Down is where the projector is above the model, Bottom up is where the projector is below the model."))
         fieldsizer.Add(self.direction, pos = (4, 1), flag = wx.ALIGN_CENTER_VERTICAL)
 
-        fieldsizer.Add(wx.StaticText(settingsGroup, -1, "Overshoot (mm):"), pos = (5, 0), flag = wx.ALIGN_CENTER_VERTICAL)
+        fieldsizer.Add(wx.StaticText(settingsGroup, -1, _("Overshoot (mm):")), pos = (5, 0), flag = wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
         self.overshoot = wx.SpinCtrlDouble(settingsGroup, -1, initial = self._get_setting('project_overshoot', 3.0), inc = 0.1, min = 0, size = (125, -1))
         self.overshoot.SetDigits(1)
         self.overshoot.Bind(wx.EVT_SPINCTRLDOUBLE, self.update_overshoot)
-        self.overshoot.SetToolTip("How far the axis should move beyond the next slice position for each slice. For Top Down printers this would dunk the model under the resi and then return. For Bottom Up printers this would raise the base away from the vat and then return.")
+        self.overshoot.SetToolTip(_("How far the axis should move beyond the next slice position for each slice. For Top Down printers this would dunk the model under the resi and then return. For Bottom Up printers this would raise the base away from the vat and then return."))
         fieldsizer.Add(self.overshoot, pos = (5, 1))
 
-        fieldsizer.Add(wx.StaticText(settingsGroup, -1, "Pre-lift Gcode:"), pos = (6, 0), flag = wx.ALIGN_CENTER_VERTICAL)
+        fieldsizer.Add(wx.StaticText(settingsGroup, -1, _("Pre-lift Gcode:")), pos = (6, 0), flag = wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
         self.prelift_gcode = wx.TextCtrl(settingsGroup, -1, str(self._get_setting("project_prelift_gcode", "").replace("\\n", '\n')), size = (-1, 35), style = wx.TE_MULTILINE)
-        self.prelift_gcode.SetToolTip("Additional gcode to run before raising the Z axis. Be sure to take into account any additional time needed in the pause value, and be careful what gcode is added!")
+        self.prelift_gcode.SetToolTip(_("Additional gcode to run before raising the Z-axis. Be sure to take into account any additional time needed in the pause value, and be careful what gcode is added!"))
         self.prelift_gcode.Bind(wx.EVT_TEXT, self.update_prelift_gcode)
-        fieldsizer.Add(self.prelift_gcode, pos = (6, 1), span = (2, 1))
+        fieldsizer.Add(self.prelift_gcode, pos = (6, 1), span = (2, 1), flag = wx.EXPAND)
 
-        fieldsizer.Add(wx.StaticText(settingsGroup, -1, "Post-lift Gcode:"), pos = (6, 2), flag = wx.ALIGN_CENTER_VERTICAL)
+        fieldsizer.Add(wx.StaticText(settingsGroup, -1, _("Post-lift Gcode:")), pos = (6, 2), flag = wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
         self.postlift_gcode = wx.TextCtrl(settingsGroup, -1, str(self._get_setting("project_postlift_gcode", "").replace("\\n", '\n')), size = (-1, 35), style = wx.TE_MULTILINE)
-        self.postlift_gcode.SetToolTip("Additional gcode to run after raising the Z axis. Be sure to take into account any additional time needed in the pause value, and be careful what gcode is added!")
+        self.postlift_gcode.SetToolTip(_("Additional gcode to run after raising the Z-axis. Be sure to take into account any additional time needed in the pause value, and be careful what gcode is added!"))
         self.postlift_gcode.Bind(wx.EVT_TEXT, self.update_postlift_gcode)
-        fieldsizer.Add(self.postlift_gcode, pos = (6, 3), span = (2, 1))
+        fieldsizer.Add(self.postlift_gcode, pos = (6, 3), span = (2, 1), flag = wx.EXPAND)
 
         # Right Column
 
-        fieldsizer.Add(wx.StaticText(settingsGroup, -1, "X (px):"), pos = (0, 2), flag = wx.ALIGN_CENTER_VERTICAL)
+        fieldsizer.Add(wx.StaticText(settingsGroup, -1, _("X (px):")), pos = (0, 2), flag = wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
         projectX = int(math.floor(float(self._get_setting("project_x", 1920))))
         self.X = wx.SpinCtrl(settingsGroup, -1, str(projectX), max = 999999, size = (125, -1))
         self.X.Bind(wx.EVT_SPINCTRL, self.update_resolution)
-        self.X.SetToolTip("The projector resolution in the X axis.")
+        self.X.SetToolTip(_("The projector resolution in the X axis."))
         fieldsizer.Add(self.X, pos = (0, 3))
 
-        fieldsizer.Add(wx.StaticText(settingsGroup, -1, "Y (px):"), pos = (1, 2), flag = wx.ALIGN_CENTER_VERTICAL)
+        fieldsizer.Add(wx.StaticText(settingsGroup, -1, _("Y (px):")), pos = (1, 2), flag = wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
         projectY = int(math.floor(float(self._get_setting("project_y", 1200))))
         self.Y = wx.SpinCtrl(settingsGroup, -1, str(projectY), max = 999999, size = (125, -1))
         self.Y.Bind(wx.EVT_SPINCTRL, self.update_resolution)
-        self.Y.SetToolTip("The projector resolution in the Y axis.")
+        self.Y.SetToolTip(_("The projector resolution in the Y axis."))
         fieldsizer.Add(self.Y, pos = (1, 3))
 
-        fieldsizer.Add(wx.StaticText(settingsGroup, -1, "OffsetX (mm):"), pos = (2, 2), flag = wx.ALIGN_CENTER_VERTICAL)
+        fieldsizer.Add(wx.StaticText(settingsGroup, -1, _("Offset X (mm):")), pos = (2, 2), flag = wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
         self.offset_X = wx.SpinCtrlDouble(settingsGroup, -1, initial = self._get_setting("project_offset_x", 0.0), inc = 1, size = (125, -1))
         self.offset_X.SetDigits(1)
         self.offset_X.Bind(wx.EVT_SPINCTRLDOUBLE, self.update_offset)
-        self.offset_X.SetToolTip("How far the slice should be offset from the edge in the X axis.")
+        self.offset_X.SetToolTip(_("How far the slice should be offset from the edge in the X axis."))
         fieldsizer.Add(self.offset_X, pos = (2, 3))
 
-        fieldsizer.Add(wx.StaticText(settingsGroup, -1, "OffsetY (mm):"), pos = (3, 2), flag = wx.ALIGN_CENTER_VERTICAL)
+        fieldsizer.Add(wx.StaticText(settingsGroup, -1, _("Offset Y (mm):")), pos = (3, 2), flag = wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
         self.offset_Y = wx.SpinCtrlDouble(settingsGroup, -1, initial = self._get_setting("project_offset_y", 0.0), inc = 1, size = (125, -1))
         self.offset_Y.SetDigits(1)
         self.offset_Y.Bind(wx.EVT_SPINCTRLDOUBLE, self.update_offset)
-        self.offset_Y.SetToolTip("How far the slice should be offset from the edge in the Y axis.")
+        self.offset_Y.SetToolTip(_("How far the slice should be offset from the edge in the Y axis."))
         fieldsizer.Add(self.offset_Y, pos = (3, 3))
 
-        fieldsizer.Add(wx.StaticText(settingsGroup, -1, "ProjectedX (mm):"), pos = (4, 2), flag = wx.ALIGN_CENTER_VERTICAL)
+        fieldsizer.Add(wx.StaticText(settingsGroup, -1, _("Projected X (mm):")), pos = (4, 2), flag = wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
         self.projected_X_mm = wx.SpinCtrlDouble(settingsGroup, -1, initial = self._get_setting("project_projected_x", 505.0), inc = 1, size = (125, -1))
         self.projected_X_mm.SetDigits(1)
         self.projected_X_mm.Bind(wx.EVT_SPINCTRLDOUBLE, self.update_projected_Xmm)
-        self.projected_X_mm.SetToolTip("The actual width of the entire projected image. Use the Calibrate grid to show the full size of the projected image, and measure the width at the same level where the slice will be projected onto the resin.")
+        self.projected_X_mm.SetToolTip(_("The actual width of the entire projected image. Use the Calibrate grid to show the full size of the projected image, and measure the width at the same level where the slice will be projected onto the resin."))
         fieldsizer.Add(self.projected_X_mm, pos = (4, 3))
 
-        fieldsizer.Add(wx.StaticText(settingsGroup, -1, "Z Axis Speed (mm/min):"), pos = (5, 2), flag = wx.ALIGN_CENTER_VERTICAL)
+        fieldsizer.Add(wx.StaticText(settingsGroup, -1, _("Z-Axis Speed (mm/min):")), pos = (5, 2), flag = wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
         self.z_axis_rate = wx.SpinCtrl(settingsGroup, -1, str(self._get_setting("project_z_axis_rate", 200)), max = 9999, size = (125, -1))
         self.z_axis_rate.Bind(wx.EVT_SPINCTRL, self.update_z_axis_rate)
-        self.z_axis_rate.SetToolTip("Speed of the Z axis in mm/minute. Take into account that slower rates may require a longer pause value.")
+        self.z_axis_rate.SetToolTip(_("Speed of the Z axis in mm/minute. Take into account that slower rates may require a longer pause value."))
         fieldsizer.Add(self.z_axis_rate, pos = (5, 3))
 
         fieldboxsizer.Add(fieldsizer)
 
         # Display
 
-        displayGroup = wx.StaticBox(self.panel, -1, "Display")
+        displayGroup = wx.StaticBox(self.panel, -1, _("Display"))
         displayboxsizer = wx.StaticBoxSizer(displayGroup)
-        displaysizer = wx.GridBagSizer(10, 10)
+        displaysizer = wx.GridBagSizer(vgap = getSpace('minor'), hgap = getSpace('minor'))
 
-        self.fullscreen = wx.CheckBox(displayGroup, -1, "Fullscreen")
+        self.fullscreen = wx.CheckBox(displayGroup, -1, _("Fullscreen"))
         self.fullscreen.Bind(wx.EVT_CHECKBOX, self.update_fullscreen)
-        self.fullscreen.SetToolTip("Toggles the project screen to full size.")
+        self.fullscreen.SetToolTip(_("Toggles the project screen to full size."))
         displaysizer.Add(self.fullscreen, pos = (0, 0), flag = wx.ALIGN_CENTER_VERTICAL)
 
-        self.calibrate = wx.CheckBox(displayGroup, -1, "Calibrate:")
+        self.calibrate = wx.CheckBox(displayGroup, -1, _("Calibrate"))
         self.calibrate.Bind(wx.EVT_CHECKBOX, self.show_calibrate)
-        self.calibrate.SetToolTip("Toggles the calibration grid. Each grid should be 10mmx10mm in size. Use the grid to ensure the projected size is correct. See also the help for the ProjectedX field.")
+        self.calibrate.SetToolTip(_("Toggles the calibration grid. Each grid should be 10mmx10mm in size. Use the grid to ensure the projected size is correct. See also the help for the ProjectedX field."))
         displaysizer.Add(self.calibrate, pos = (0, 1), flag = wx.ALIGN_CENTER_VERTICAL)
 
         first_layer_boxer = wx.BoxSizer(wx.HORIZONTAL)
-        self.first_layer = wx.CheckBox(displayGroup, -1, "1st Layer")
+        self.first_layer = wx.CheckBox(displayGroup, -1, _("1st Layer"))
         self.first_layer.Bind(wx.EVT_CHECKBOX, self.show_first_layer)
-        self.first_layer.SetToolTip("Displays the first layer of the model. Use this to project the first layer for longer so it holds to the base. Note: this value does not affect the first layer when the \"Present\" run is started, it should be used manually.")
+        self.first_layer.SetToolTip(_("Displays the first layer of the model. Use this to project the first layer for longer so it holds to the base. Note: this value does not affect the first layer when the \"Present\" run is started, it should be used manually."))
 
         first_layer_boxer.Add(self.first_layer, flag = wx.ALIGN_CENTER_VERTICAL)
 
         first_layer_boxer.Add(wx.StaticText(displayGroup, -1, " (s):"), flag = wx.ALIGN_CENTER_VERTICAL)
-        self.show_first_layer_timer = wx.SpinCtrlDouble(displayGroup, -1, initial = -1, min=-1, inc = 1, size = (125, -1))
+        self.show_first_layer_timer = wx.SpinCtrlDouble(displayGroup, -1, initial = -1, min = -1, inc = 1, size = (125, -1))
         self.show_first_layer_timer.SetDigits(1)
-        self.show_first_layer_timer.SetToolTip("How long to display the first layer for. -1 = unlimited.")
+        self.show_first_layer_timer.SetToolTip(_("How long to display the first layer for. -1 = unlimited."))
         first_layer_boxer.Add(self.show_first_layer_timer, flag = wx.ALIGN_CENTER_VERTICAL)
         displaysizer.Add(first_layer_boxer, pos = (0, 2), flag = wx.ALIGN_CENTER_VERTICAL)
 
-        self.layer_red = wx.CheckBox(displayGroup, -1, "Red")
+        self.layer_red = wx.CheckBox(displayGroup, -1, _("Red"))
         self.layer_red.Bind(wx.EVT_CHECKBOX, self.show_layer_red)
-        self.layer_red.SetToolTip("Toggles whether the image should be red. Useful for positioning whilst resin is in the printer as it should not cause a reaction.")
+        self.layer_red.SetToolTip(_("Toggles whether the image should be red. Useful for positioning whilst resin is in the printer as it should not cause a reaction."))
         displaysizer.Add(self.layer_red, pos = (0, 3), flag = wx.ALIGN_CENTER_VERTICAL)
 
         displayboxsizer.Add(displaysizer)
 
         # Info
-        infoGroup = wx.StaticBox(self.panel, label = "Info")
+        infoGroup = wx.StaticBox(self.panel, label = _("Info"))
         infosizer = wx.StaticBoxSizer(infoGroup, wx.VERTICAL)
 
-        infofieldsizer = wx.GridBagSizer(10, 10)
+        infofieldsizer = wx.GridBagSizer(vgap = getSpace('minor'), hgap = getSpace('minor'))
 
-        filelabel = wx.StaticText(infoGroup, -1, "File:")
-        filelabel.SetToolTip("The name of the model currently loaded.")
-        infofieldsizer.Add(filelabel, pos = (0, 0))
+        filelabel = wx.StaticText(infoGroup, -1, _("File:"))
+        filelabel.SetToolTip(_("The name of the model currently loaded."))
+        infofieldsizer.Add(filelabel, pos = (0, 0), flag = wx.ALIGN_RIGHT)
         self.filename = wx.StaticText(infoGroup, -1, "")
-        infofieldsizer.Add(self.filename, pos = (0, 1))
+        infofieldsizer.Add(self.filename, pos = (0, 1), flag = wx.EXPAND)
 
-        totallayerslabel = wx.StaticText(infoGroup, -1, "Total Layers:")
-        totallayerslabel.SetToolTip("The total number of layers found in the model.")
-        infofieldsizer.Add(totallayerslabel, pos = (1, 0))
+        totallayerslabel = wx.StaticText(infoGroup, -1, _("Total Layers:"))
+        totallayerslabel.SetToolTip(_("The total number of layers found in the model."))
+        infofieldsizer.Add(totallayerslabel, pos = (1, 0), flag = wx.ALIGN_RIGHT)
         self.total_layers = wx.StaticText(infoGroup, -1)
+        infofieldsizer.Add(self.total_layers, pos = (1, 1), flag = wx.EXPAND)
 
-        infofieldsizer.Add(self.total_layers, pos = (1, 1))
-
-        currentlayerlabel = wx.StaticText(infoGroup, -1, "Current Layer:")
-        currentlayerlabel.SetToolTip("The current layer being displayed.")
-        infofieldsizer.Add(currentlayerlabel, pos = (2, 0))
+        currentlayerlabel = wx.StaticText(infoGroup, -1, _("Current Layer:"))
+        currentlayerlabel.SetToolTip(_("The current layer being displayed."))
+        infofieldsizer.Add(currentlayerlabel, pos = (2, 0), flag = wx.ALIGN_RIGHT)
         self.current_layer = wx.StaticText(infoGroup, -1, "0")
-        infofieldsizer.Add(self.current_layer, pos = (2, 1))
+        infofieldsizer.Add(self.current_layer, pos = (2, 1), flag = wx.EXPAND)
 
-        estimatedtimelabel = wx.StaticText(infoGroup, -1, "Estimated Time:")
-        estimatedtimelabel.SetToolTip("An estimate of the remaining time until print completion.")
-        infofieldsizer.Add(estimatedtimelabel, pos = (3, 0))
+        estimatedtimelabel = wx.StaticText(infoGroup, -1, _("Estimated Time:"))
+        estimatedtimelabel.SetToolTip(_("An estimate of the remaining time until print completion."))
+        infofieldsizer.Add(estimatedtimelabel, pos = (3, 0), flag = wx.ALIGN_RIGHT)
         self.estimated_time = wx.StaticText(infoGroup, -1, "")
-        infofieldsizer.Add(self.estimated_time, pos = (3, 1))
+        infofieldsizer.Add(self.estimated_time, pos = (3, 1), flag = wx.EXPAND)
 
-        infosizer.Add(infofieldsizer)
+        statuslabel = wx.StaticText(infoGroup, -1, _("Status:"))
+        statuslabel.SetToolTip(_("Latest activity, informational and error messages."))
+        infofieldsizer.Add(statuslabel, pos=(4, 0), flag = wx.ALIGN_RIGHT)
+        self.statusbar = wx.StaticText(infoGroup, -1, "", style = wx.ELLIPSIZE_END)
+        infofieldsizer.Add(self.statusbar, pos = (4, 1), flag = wx.EXPAND)
+
+        infofieldsizer.AddGrowableCol(1)
+        infosizer.Add(infofieldsizer, 1, wx.EXPAND)
 
         #
         vbox = wx.BoxSizer(wx.VERTICAL)
-        vbox.Add(buttonbox, flag = wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP | wx.BOTTOM, border = 10)
-        vbox.Add(fieldboxsizer, flag = wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, border = 10)
-        vbox.Add(displayboxsizer, flag = wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, border = 10)
-        vbox.Add(infosizer, flag = wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, border = 10)
-
+        vbox.Add(buttonbox, flag = wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP | wx.BOTTOM, border = getSpace('minor'))
+        vbox.Add(fieldboxsizer, flag = wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, border = getSpace('minor'))
+        vbox.Add(displayboxsizer, flag = wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, border = getSpace('minor'))
+        vbox.Add(infosizer, flag = wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, border = getSpace('minor'))
         self.panel.SetSizerAndFit(vbox)
-        bs = wx.BoxSizer(wx.VERTICAL)
-        bs.Add(self.panel, flag=wx.EXPAND)
-        self.SetSizerAndFit(bs)
+
+        reset_button = wx.Button(self, -1, label=_("Reset"))
+        close_button = wx.Button(self, wx.ID_CLOSE)
+        bottom_button_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        bottom_button_sizer.Add(reset_button, 0)
+        bottom_button_sizer.AddStretchSpacer(1)
+        bottom_button_sizer.Add(close_button, 0)
+
+        topsizer = wx.BoxSizer(wx.VERTICAL)
+        topsizer.Add(self.panel, wx.EXPAND | wx.BOTTOM, getSpace('mini'))
+        topsizer.Add(wx.StaticLine(self, -1, style = wx.LI_HORIZONTAL), 0, wx.EXPAND)
+        topsizer.Add(bottom_button_sizer, 0, wx.EXPAND | wx.ALL, getSpace('stddlg-frame'))
+
+        self.Bind(wx.EVT_BUTTON, self.on_close, id=wx.ID_CLOSE)
+        self.Bind(wx.EVT_CLOSE, self.on_close)
+        reset_button.Bind(wx.EVT_BUTTON, self.reset_all)
+
+        self.SetSizerAndFit(topsizer)
         self.Fit()
         #self.SetPosition((0, 0))
         self.CentreOnParent()
@@ -487,7 +517,7 @@ class SettingsFrame(wx.Frame):
         if not hasattr(self, 'layers'):
             return
 
-        current_layer = int(self.current_layer.GetLabel())
+        current_layer = int(float(self.current_layer.GetLabel()))
         remaining_layers = len(self.layers[0]) - current_layer
         # 0.5 for delay between hide and rise
         estimated_time = remaining_layers * (float(self.interval.GetValue()) + float(self.pause.GetValue()) + 0.5)
@@ -559,7 +589,7 @@ class SettingsFrame(wx.Frame):
 
     def parse_3DLP_zip(self, name):
         if not zipfile.is_zipfile(name):
-            raise Exception(name + " is not a zip file!")
+            raise Exception(name + _(" is not a zip file!"))
         accepted_image_types = ['gif', 'tiff', 'jpg', 'jpeg', 'bmp', 'png']
         zipFile = zipfile.ZipFile(name, 'r')
         self.image_dir = tempfile.mkdtemp()
@@ -583,22 +613,24 @@ class SettingsFrame(wx.Frame):
         return ol, -1, "bitmap"
 
     def load_file(self, event):
-        dlg = wx.FileDialog(self, ("Open file to print"), style = wx.FD_OPEN | wx.FD_FILE_MUST_EXIST)
-        dlg.SetWildcard(("Slic3r or Skeinforge svg files (;*.svg;*.SVG;);3DLP Zip (;*.3dlp.zip;)"))
+        dlg = wx.FileDialog(self, _("Open file to print"), style = wx.FD_OPEN | wx.FD_FILE_MUST_EXIST)
+        dlg.SetWildcard(_("Slic3r or Skeinforge svg files (;*.svg;*.SVG;);3DLP Zip (;*.3dlp.zip;)"))
         if dlg.ShowModal() == wx.ID_OK:
             name = dlg.GetPath()
             if not(os.path.exists(name)):
-                self.status.SetStatusText(("File not found!"))
+                self.status.SetStatusText(_("File not found!"))
                 return
             if name.endswith(".3dlp.zip"):
                 layers = self.parse_3DLP_zip(name)
                 layerHeight = float(self.thickness.GetValue())
             else:
                 layers = self.parse_svg(name)
-                layerHeight = layers[1]
-                self.thickness.SetValue(str(layers[1]))
-                print("Layer thickness detected:", layerHeight, "mm")
-            print(len(layers[0]), "layers found, total height", layerHeight * len(layers[0]), "mm")
+                #layerHeight = layers[1]
+                # Caution: *1000000 is a special adjustment to dislpay the Slic3r .svg files correctly.
+                layerHeight = float(f"{layers[1]*1000000:.2f}")
+                self.thickness.SetValue(str(layerHeight))
+                self.statusbar.SetLabel(_("Layer thickness detected: %s mm") % layerHeight)
+            self.statusbar.SetLabel(_("%s layers found, total height %s mm") % (len(layers[0]), layerHeight * len(layers[0])))
             self.layers = layers
             self.set_total_layers(len(layers[0]))
             self.set_current_layer(0)
@@ -606,6 +638,7 @@ class SettingsFrame(wx.Frame):
             self.display_filename(self.current_filename)
             self.slicer = layers[2]
             self.display_frame.slicer = self.slicer
+            self.present_button.Enable()
         dlg.Destroy()
 
     def show_calibrate(self, event):
@@ -663,17 +696,18 @@ class SettingsFrame(wx.Frame):
 
             for y in range(0, gridCountY + 1):
                 for x in range(0, gridCountX + 1):
-                    dc.DrawLine(0, y * (pixelsYPerMM * 10), resolution_x_pixels, y * (pixelsYPerMM * 10))
-                    dc.DrawLine(x * (pixelsXPerMM * 10), 0, x * (pixelsXPerMM * 10), resolution_y_pixels)
+                    dc.DrawLine(0, int(y * (pixelsYPerMM * 10)), resolution_x_pixels, int(y * (pixelsYPerMM * 10)))
+                    dc.DrawLine(int(x * (pixelsXPerMM * 10)), 0, int(x * (pixelsXPerMM * 10)), resolution_y_pixels)
 
             self.first_layer.SetValue(False)
             self.display_frame.slicer = 'bitmap'
             self.display_frame.draw_layer(gridBitmap.ConvertToImage())
+        self.Raise()
 
     def present_first_layer(self, event):
         if self.first_layer.GetValue():
             if not hasattr(self, "layers"):
-                print("No model loaded!")
+                self.statusbar.SetLabel(_("No model loaded!"))
                 self.first_layer.SetValue(False)
                 return
             self.display_frame.offset = (float(self.offset_X.GetValue()), float(self.offset_Y.GetValue()))
@@ -706,8 +740,23 @@ class SettingsFrame(wx.Frame):
         self.present_first_layer(event)
 
     def update_thickness(self, event):
-        self._set_setting('project_layer', self.thickness.GetValue())
-        self.refresh_display(event)
+        layer = self.thickness.GetValue()
+
+        if ',' in layer:
+            self.statusbar.SetLabel(_("'Layer' contains a comma, please use a point for decimal values."))
+            self.Layout() # Layout() is needed to ellipsize possible overlength status
+            return False
+
+        try:
+            float(layer)
+        except ValueError:
+            self.statusbar.SetLabel(_("Unrecognized number in 'Layer': %s") % layer)
+            #self.Layout() # Layout() is needed to ellipsize possible overlength status
+            return False
+        else:
+            self.statusbar.SetLabel("")
+            self._set_setting('project_layer', float(layer))
+            self.refresh_display(event)
 
     def update_projected_Xmm(self, event):
         self._set_setting('project_projected_x', self.projected_X_mm.GetValue())
@@ -720,18 +769,44 @@ class SettingsFrame(wx.Frame):
         self.refresh_display(event)
 
     def update_interval(self, event):
-        interval = float(self.interval.GetValue())
-        self.display_frame.interval = interval
-        self._set_setting('project_interval', interval)
-        self.set_estimated_time()
-        self.refresh_display(event)
+        interval = self.interval.GetValue()
+
+        if ',' in interval:
+            self.statusbar.SetLabel(_("'Exposure' contains a comma, please use a point for decimal values."))
+            self.Layout() # Layout() is needed to ellipsize possible overlength status
+            return False
+
+        try:
+            float(interval)
+        except ValueError:
+            self.statusbar.SetLabel(_("Unrecognized number in 'Exposure': %s") % interval)
+            return False
+        else:
+            self.statusbar.SetLabel("")
+            self.display_frame.interval = float(interval)
+            self._set_setting('project_interval', float(self.interval.GetValue()))
+            self.set_estimated_time()
+            self.refresh_display(event)
 
     def update_pause(self, event):
-        pause = float(self.pause.GetValue())
-        self.display_frame.pause = pause
-        self._set_setting('project_pause', pause)
-        self.set_estimated_time()
-        self.refresh_display(event)
+        pause = self.pause.GetValue()
+
+        if ',' in pause:
+            self.statusbar.SetLabel(_("'Blank' contains a comma, please HHHHHHHHHHHHHHHHHHHHuse a point for decimal values."))
+            self.Layout() # Layout() is needed to ellipsize possible overlength status
+            return False
+
+        try:
+            float(pause)
+        except ValueError:
+            self.statusbar.SetLabel(_("Unrecognized number in 'Blank': %s") % pause)
+            return False
+        else:
+            self.statusbar.SetLabel("")
+            self.display_frame.pause = float(pause)
+            self._set_setting('project_pause', float(pause))
+            self.set_estimated_time()
+            self.refresh_display(event)
 
     def update_overshoot(self, event):
         overshoot = float(self.overshoot.GetValue())
@@ -754,7 +829,7 @@ class SettingsFrame(wx.Frame):
         self._set_setting('project_z_axis_rate', z_axis_rate)
 
     def update_direction(self, event):
-        direction = self.direction.GetValue()
+        direction = self.direction.GetSelection()
         self.display_frame.direction = direction
         self._set_setting('project_direction', direction)
 
@@ -764,6 +839,7 @@ class SettingsFrame(wx.Frame):
         else:
             self.display_frame.ShowFullScreen(0)
         self.refresh_display(event)
+        self.Raise()
 
     def update_resolution(self, event):
         x = int(self.X.GetValue())
@@ -782,10 +858,12 @@ class SettingsFrame(wx.Frame):
 
     def start_present(self, event):
         if not hasattr(self, "layers"):
-            print("No model loaded!")
+            self.statusbar.SetLabel(_("No model loaded!"))
             return
-
-        self.pause_button.SetLabel("Pause")
+        self.statusbar.SetLabel(_("Starting..."))
+        self.pause_button.SetLabel(self.getButtonLabel('pause'))
+        self.pause_button.Enable()
+        self.stop_button.Enable()
         self.set_current_layer(0)
         self.display_frame.Raise()
         if self.fullscreen.GetValue():
@@ -801,27 +879,102 @@ class SettingsFrame(wx.Frame):
                                    z_axis_rate = int(self.z_axis_rate.GetValue()),
                                    prelift_gcode = self.prelift_gcode.GetValue(),
                                    postlift_gcode = self.postlift_gcode.GetValue(),
-                                   direction = self.direction.GetValue(),
+                                   direction = self.direction.GetSelection(),
                                    size = (float(self.X.GetValue()), float(self.Y.GetValue())),
                                    offset = (float(self.offset_X.GetValue()), float(self.offset_Y.GetValue())),
                                    layer_red = self.layer_red.IsChecked())
+        self.present_button.Disable()
+        self.Raise()
 
     def stop_present(self, event):
-        print("Stop")
-        self.pause_button.SetLabel("Pause")
-        self.set_current_layer(0)
+        self.statusbar.SetLabel(_("Stopping..."))
         self.display_frame.running = False
+        self.pause_button.SetLabel(self.getButtonLabel('pause'))
+        self.set_current_layer(0)
+        self.present_button.Enable()
+        self.pause_button.Disable()
+        self.stop_button.Disable()
+        self.statusbar.SetLabel(_("Stop"))
 
     def pause_present(self, event):
-        if self.pause_button.GetLabel() == 'Pause':
-            print("Pause")
-            self.pause_button.SetLabel("Continue")
+        if self.pause_button.GetLabel() == self.getButtonLabel('pause'):
+            self.statusbar.SetLabel(self.getButtonLabel('pause'))
+            self.pause_button.SetLabel(self.getButtonLabel('continue'))
             self.display_frame.running = False
         else:
-            print("Continue")
-            self.pause_button.SetLabel("Pause")
+            self.statusbar.SetLabel(self.getButtonLabel('continue'))
+            self.pause_button.SetLabel(self.getButtonLabel('pause'))
             self.display_frame.running = True
             self.display_frame.next_img()
+
+    def on_close(self, event):
+        self.stop_present(event)
+        if self.display_frame:
+            self.display_frame.Destroy()
+        self.Destroy()
+
+    def getButtonLabel(self, value):
+        # This method simplifies translation of the button label
+        if value == 'pause':
+            return _("Pause")
+        elif value == 'continue':
+            return _("Continue")
+        else:
+            return "ErrorButtonLabel"
+        
+    def reset_all(self, event):
+        # Ask confirmation for deleting
+        reset_dialog = wx.MessageDialog(self,
+            message = _("Are you sure you want to reset all the settings to the defaults?\nBe aware that the defaults are not guaranteed to work well with your machine."),
+            caption = _("Reset ProjectLayer Settings"),
+            style = wx.YES_NO | wx.ICON_EXCLAMATION)
+
+        if reset_dialog.ShowModal() == wx.ID_YES:
+            # Reset all settings
+            std_settings = [
+                [ self.thickness, "0.1", self.update_thickness],
+                [ self.interval, "2.0", self.update_interval],
+                [ self.pause, "2.5", self.update_pause],
+                [ self.scale, 1.0, self.update_scale],
+                [ self.overshoot, 3.0, self.update_overshoot],
+                [ self.prelift_gcode, "", self.update_prelift_gcode],
+
+                [ self.X, 1024, self.update_resolution],
+                [ self.Y, 768, self.update_resolution],
+                [ self.offset_X, 0, self.update_offset],
+                [ self.offset_Y, 0, self.update_offset],
+                [ self.projected_X_mm, 100.0, self.update_projected_Xmm],
+                [ self.z_axis_rate, 200, self.update_z_axis_rate],
+                [ self.postlift_gcode, "", self.update_postlift_gcode],
+                
+                [ self.fullscreen, False, self.update_fullscreen],
+                [ self.calibrate, False, self.show_calibrate],
+                [ self.first_layer, False, self.show_first_layer],
+                [ self.show_first_layer_timer, -1.0, self.show_first_layer_timer],
+                [ self.layer_red, False, self.show_layer_red]
+            ]
+
+            for setting in std_settings:
+                self.reset_setting(event, setting[0], setting[1], setting[2])
+
+            # Direction is separate because it can't be set with SetValue but SetSelection instead
+            #[ self.direction, 0, self.update_direction]
+            if not 0 == self.direction.GetSelection():
+                self.direction.SetSelection(0)
+                self.update_direction(event)
+
+            self.filename.SetLabel("")
+            self.total_layers.SetLabel("")
+            self.current_layer.SetLabel("0")
+            self.estimated_time.SetLabel("")        
+            self.statusbar.SetLabel(_("ProjectLayer Settings Reset"))
+
+    def reset_setting(self, event, name, value, update_function):
+        # First check if the user actually changed the setting
+        if not value == name.GetValue():
+            # If so, set it back and invoke the update_function to save the value
+            name.SetValue(value)
+            update_function(event)
 
 if __name__ == "__main__":
     a = wx.App()

--- a/printrun/projectlayer.py
+++ b/printrun/projectlayer.py
@@ -15,7 +15,6 @@
 
 import xml.etree.ElementTree
 import wx
-import wx.lib.agw.floatspin as floatspin
 import os
 import time
 import zipfile
@@ -28,7 +27,7 @@ import copy
 import re
 from collections import OrderedDict
 import math
-from printrun.gui.widgets import getSpace
+from printrun.gui.widgets import get_space
 
 class DisplayFrame(wx.Frame):
     def __init__(self, parent, title, res = (1024, 768), printer = None, scale = 1.0, offset = (0, 0)):
@@ -49,7 +48,6 @@ class DisplayFrame(wx.Frame):
         self.SetBackgroundColour("black")
         self.pic.Hide()
         self.SetDoubleBuffered(True)
-        #self.SetPosition((self.control_frame.GetSize().x / 2, 24))
         self.CentreOnParent()
         self.Show()
 
@@ -71,7 +69,6 @@ class DisplayFrame(wx.Frame):
             self.Refresh()
         except:
             raise
-            pass
 
     def resize(self, res = (1024, 768)):
         self.bitmap = wx.Bitmap(*res)
@@ -89,7 +86,7 @@ class DisplayFrame(wx.Frame):
             dc.SetBackground(wx.Brush("black"))
             dc.Clear()
 
-            if self.slicer == 'Slic3r' or self.slicer == 'Skeinforge':
+            if self.slicer in ['Slic3r', 'Skeinforge']:
 
                 if self.scale != 1.0:
                     image = copy.deepcopy(image)
@@ -106,12 +103,12 @@ class DisplayFrame(wx.Frame):
                 pngbytes = PNGSurface.convert(dpi = self.dpi, bytestring = xml.etree.ElementTree.tostring(image))
                 pngImage = wx.Image(io.BytesIO(pngbytes))
 
-                #self.statusbar.SetLabel("w:", pngImage.Width, ", dpi:", self.dpi, ", w (mm): ",(pngImage.Width / self.dpi) * 25.4)
+                self.Parent.statusbar.SetLabel(f"Width: {pngImage.Width}, dpi: {self.dpi:.2f} -> Width: {((pngImage.Width / self.dpi) * 25.4):.3f} mm")
 
                 if self.layer_red:
                     pngImage = pngImage.AdjustChannels(1, 0, 0, 1)
 
-                # AGE2022-07-31 Python 3.10 and DrawBitmap expects offset 
+                # AGE2022-07-31 Python 3.10 and DrawBitmap expects offset
                 # as integer value. Convert float values to int
                 dc.DrawBitmap(wx.Bitmap(pngImage), int(self.offset[0]), int(self.offset[1]), True)
 
@@ -120,9 +117,9 @@ class DisplayFrame(wx.Frame):
                     image = wx.Image(image)
                 if self.layer_red:
                     image = image.AdjustChannels(1, 0, 0, 1)
-                # AGE2023-04-19 Python 3.10 and DrawBitmap expects offset 
+                # AGE2023-04-19 Python 3.10 and DrawBitmap expects offset
                 # as integer value. Convert float values to int
-                bitmap = wx.Bitmap(image.Scale(int(image.Width * self.scale), int(image.Height * self.scale))) #*
+                bitmap = wx.Bitmap(image.Scale(int(image.Width * self.scale), int(image.Height * self.scale)))
                 dc.DrawBitmap(bitmap, int(self.offset[0]), int(-self.offset[1]), True)
             else:
                 raise Exception(self.slicer + _(" is an unknown method."))
@@ -133,20 +130,19 @@ class DisplayFrame(wx.Frame):
 
         except:
             raise
-            pass
 
     def show_img_delay(self, image):
         self.Parent.statusbar.SetLabel(_("Showing, Timestamp %s s") % str(time.perf_counter()))
         self.control_frame.set_current_layer(self.index)
         self.draw_layer(image)
-        # AGe 2022-07-31 Python 3.10 and CallLater expects delay in milliseconds as 
+        # AGe 2022-07-31 Python 3.10 and CallLater expects delay in milliseconds as
         # integer value instead of float. Convert float value to int
         wx.CallLater(int(1000 * self.interval), self.hide_pic_and_rise)
 
     def rise(self):
-        if self.direction == 0: # 0: Top Down
+        if self.direction == 0:  # 0: Top Down
             self.Parent.statusbar.SetLabel(_("Lowering, Timestamp %s s") % str(time.perf_counter()))
-        else: # self.direction == 1, 1: Bottom Up
+        else:  # self.direction == 1, 1: Bottom Up
             self.Parent.statusbar.SetLabel(_("Rising, Timestamp %s s") % str(time.perf_counter()))
 
         if self.printer is not None and self.printer.online:
@@ -157,10 +153,10 @@ class DisplayFrame(wx.Frame):
                     if line:
                         self.printer.send_now(line)
 
-            if self.direction == 0: # 0: Top Down
+            if self.direction == 0:  # 0: Top Down
                 self.printer.send_now("G1 Z-%f F%g" % (self.overshoot, self.z_axis_rate,))
                 self.printer.send_now("G1 Z%f F%g" % (self.overshoot - self.thickness, self.z_axis_rate,))
-            else: # self.direction == 1, 1: Bottom Up
+            else:  # self.direction == 1, 1: Bottom Up
                 self.printer.send_now("G1 Z%f F%g" % (self.overshoot, self.z_axis_rate,))
                 self.printer.send_now("G1 Z-%f F%g" % (self.overshoot - self.thickness, self.z_axis_rate,))
 
@@ -173,7 +169,8 @@ class DisplayFrame(wx.Frame):
         else:
             time.sleep(self.pause)
 
-        # AGe 2022-07-31 Python 3.10 expects delay in milliseconds as integer value instead of float. Convert float value to int
+        # AGe 2022-07-31 Python 3.10 expects delay in milliseconds as
+        # integer value instead of float. Convert float value to int
         wx.CallLater(int(1000 * self.pause), self.next_img)
 
     def hide_pic(self):
@@ -204,7 +201,7 @@ class DisplayFrame(wx.Frame):
                 z_axis_rate = 200,
                 prelift_gcode = "",
                 postlift_gcode = "",
-                direction = 0, # 0: Top Down
+                direction = 0,  # 0: Top Down
                 thickness = 0.4,
                 scale = 1,
                 size = (1024, 768),
@@ -246,7 +243,8 @@ class SettingsFrame(wx.Dialog):
             return val
 
     def __init__(self, parent, printer = None):
-        wx.Dialog.__init__(self, parent, title = _("ProjectLayer Control"), style = (wx.DEFAULT_DIALOG_STYLE | wx.DIALOG_NO_PARENT))
+        wx.Dialog.__init__(self, parent, title = _("ProjectLayer Control"),
+                           style = wx.DEFAULT_DIALOG_STYLE | wx.DIALOG_NO_PARENT)
         self.pronterface = parent
         self.display_frame = DisplayFrame(self, title = _("ProjectLayer Display"), printer = printer)
 
@@ -264,37 +262,42 @@ class SettingsFrame(wx.Dialog):
 
         load_button = wx.Button(buttonGroup, -1, _("Load"))
         load_button.Bind(wx.EVT_BUTTON, self.load_file)
-        load_button.SetToolTip(_("Choose an SVG file created from Slic3r or Skeinforge, or a zip file of bitmap images (with extension: .3dlp.zip)."))
-        buttonbox.Add(load_button, 1, flag = wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, border = getSpace('mini'))
+        load_button.SetToolTip(_("Choose an SVG file created from Slic3r or Skeinforge, or a zip file of bitmap images (Extension: .3dlp.zip)."))
+        buttonbox.Add(load_button, 1,
+                      flag = wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, border = get_space('mini'))
 
         self.present_button = wx.Button(buttonGroup, -1, _("Start"))
         self.present_button.Bind(wx.EVT_BUTTON, self.start_present)
         self.present_button.SetToolTip(_("Starts the presentation of the slices."))
-        buttonbox.Add(self.present_button, 1, flag = wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, border = getSpace('mini'))
+        buttonbox.Add(self.present_button, 1,
+                      flag = wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, border = get_space('mini'))
         self.present_button.Disable()
 
-        self.pause_button = wx.Button(buttonGroup, -1, self.getButtonLabel('pause'))
+        self.pause_button = wx.Button(buttonGroup, -1, self.get_btn_label('pause'))
         self.pause_button.Bind(wx.EVT_BUTTON, self.pause_present)
-        self.pause_button.SetToolTip(_("Pauses the presentation. Can be resumed afterwards by clicking this button, or restarted by clicking start again."))
-        buttonbox.Add(self.pause_button, 1, flag = wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, border = getSpace('mini'))
+        self.pause_button.SetToolTip(_("Pauses the presentation. Can be resumed afterwards by clicking this button,") +
+                                     _(" or restarted by clicking start again."))
+        buttonbox.Add(self.pause_button, 1,
+                      flag = wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, border = get_space('mini'))
         self.pause_button.Disable()
 
         self.stop_button = wx.Button(buttonGroup, -1, _("Stop"))
         self.stop_button.Bind(wx.EVT_BUTTON, self.stop_present)
         self.stop_button.SetToolTip(_("Stops presenting the slices."))
-        buttonbox.Add(self.stop_button, 1, flag = wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, border = getSpace('mini'))
+        buttonbox.Add(self.stop_button, 1,
+                      flag = wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, border = get_space('mini'))
         self.stop_button.Disable()
 
         settingsGroup = wx.StaticBox(self.panel, label = _("Settings"))
         fieldboxsizer = wx.StaticBoxSizer(settingsGroup, wx.VERTICAL)
-        fieldsizer = wx.GridBagSizer(vgap = getSpace('minor'), hgap = getSpace('minor'))
+        fieldsizer = wx.GridBagSizer(vgap = get_space('minor'), hgap = get_space('minor'))
 
         # Left Column
-
         fieldsizer.Add(wx.StaticText(settingsGroup, -1, _("Layer (mm):")), pos = (0, 0), flag = wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
         self.thickness = wx.TextCtrl(settingsGroup, -1, str(self._get_setting("project_layer", "0.1")), size = (125, -1))
         self.thickness.Bind(wx.EVT_TEXT, self.update_thickness)
-        self.thickness.SetToolTip(_("The thickness of each slice. Should match the value used to slice the model.  SVG files update this value automatically, 3dlp.zip files have to be manually entered."))
+        self.thickness.SetToolTip(_("The thickness of each slice. Should match the value used to slice the model.") +
+                                  _(" SVG files update this value automatically, 3dlp.zip files have to be manually entered."))
         fieldsizer.Add(self.thickness, pos = (0, 1))
 
         fieldsizer.Add(wx.StaticText(settingsGroup, -1, _("Exposure (s):")), pos = (1, 0), flag = wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
@@ -306,7 +309,8 @@ class SettingsFrame(wx.Dialog):
         fieldsizer.Add(wx.StaticText(settingsGroup, -1, _("Blank (s):")), pos = (2, 0), flag = wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
         self.pause = wx.TextCtrl(settingsGroup, -1, str(self._get_setting("project_pause", "0.5")), size = (125, -1))
         self.pause.Bind(wx.EVT_TEXT, self.update_pause)
-        self.pause.SetToolTip(_("The pause length between slices. This should take into account any movement of the Z axis, plus time to prepare the resin surface (sliding, tilting, sweeping, etc)."))
+        self.pause.SetToolTip(_("The pause length between slices. This should take into account any movement of the Z axis,") +
+                              _(" plus time to prepare the resin surface (sliding, tilting, sweeping, etc)."))
         fieldsizer.Add(self.pause, pos = (2, 1))
 
         fieldsizer.Add(wx.StaticText(settingsGroup, -1, _("Scale:")), pos = (3, 0), flag = wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
@@ -319,37 +323,43 @@ class SettingsFrame(wx.Dialog):
         fieldsizer.Add(wx.StaticText(settingsGroup, -1, _("Direction:")), pos = (4, 0), flag = wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
         self.direction = wx.Choice(settingsGroup, -1, choices = [_('Top Down'), _('Bottom Up')], size = (125, -1))
         saved_direction = self._get_setting('project_direction', 0)
-        try:
-            int(saved_direction) # This setting used to be a string, so older settings need to be overwritten
-        except:    
-            saved_direction = 0
+        try:  # This setting used to be a string, older values need to be replaced with an index
+            int(saved_direction)
+        except ValueError:
+            if saved_direction == "Bottom Up":
+                saved_direction = 1
+            else:
+                saved_direction = 0
             self._set_setting('project_direction', saved_direction)
         self.direction.SetSelection(int(saved_direction))
         self.direction.Bind(wx.EVT_CHOICE, self.update_direction)
-        self.direction.SetToolTip(_("The direction the Z axis should move. Top Down is where the projector is above the model, Bottom up is where the projector is below the model."))
+        self.direction.SetToolTip(_("The direction the Z axis should move. Top Down is where the projector is above") +
+                                  _(" the model, Bottom up is where the projector is below the model."))
         fieldsizer.Add(self.direction, pos = (4, 1), flag = wx.ALIGN_CENTER_VERTICAL)
 
         fieldsizer.Add(wx.StaticText(settingsGroup, -1, _("Overshoot (mm):")), pos = (5, 0), flag = wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
         self.overshoot = wx.SpinCtrlDouble(settingsGroup, -1, initial = self._get_setting('project_overshoot', 3.0), inc = 0.1, min = 0, size = (125, -1))
         self.overshoot.SetDigits(1)
         self.overshoot.Bind(wx.EVT_SPINCTRLDOUBLE, self.update_overshoot)
-        self.overshoot.SetToolTip(_("How far the axis should move beyond the next slice position for each slice. For Top Down printers this would dunk the model under the resi and then return. For Bottom Up printers this would raise the base away from the vat and then return."))
+        self.overshoot.SetToolTip(_("How far the axis should move beyond the next slice position for each slice. For Top Down printers this would dunk") +
+                                  _(" the model under the resi and then return. For Bottom Up printers this would raise the base away from the vat and then return."))
         fieldsizer.Add(self.overshoot, pos = (5, 1))
 
         fieldsizer.Add(wx.StaticText(settingsGroup, -1, _("Pre-lift Gcode:")), pos = (6, 0), flag = wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
         self.prelift_gcode = wx.TextCtrl(settingsGroup, -1, str(self._get_setting("project_prelift_gcode", "").replace("\\n", '\n')), size = (-1, 35), style = wx.TE_MULTILINE)
-        self.prelift_gcode.SetToolTip(_("Additional gcode to run before raising the Z-axis. Be sure to take into account any additional time needed in the pause value, and be careful what gcode is added!"))
+        self.prelift_gcode.SetToolTip(_("Additional gcode to run before raising the Z-axis.") +
+                                      _(" Be sure to take into account any additional time needed in the pause value, and be careful what gcode is added!"))
         self.prelift_gcode.Bind(wx.EVT_TEXT, self.update_prelift_gcode)
         fieldsizer.Add(self.prelift_gcode, pos = (6, 1), span = (2, 1), flag = wx.EXPAND)
 
         fieldsizer.Add(wx.StaticText(settingsGroup, -1, _("Post-lift Gcode:")), pos = (6, 2), flag = wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
         self.postlift_gcode = wx.TextCtrl(settingsGroup, -1, str(self._get_setting("project_postlift_gcode", "").replace("\\n", '\n')), size = (-1, 35), style = wx.TE_MULTILINE)
-        self.postlift_gcode.SetToolTip(_("Additional gcode to run after raising the Z-axis. Be sure to take into account any additional time needed in the pause value, and be careful what gcode is added!"))
+        self.postlift_gcode.SetToolTip(_("Additional gcode to run after raising the Z-axis.") +
+                                       _(" Be sure to take into account any additional time needed in the pause value, and be careful what gcode is added!"))
         self.postlift_gcode.Bind(wx.EVT_TEXT, self.update_postlift_gcode)
         fieldsizer.Add(self.postlift_gcode, pos = (6, 3), span = (2, 1), flag = wx.EXPAND)
 
         # Right Column
-
         fieldsizer.Add(wx.StaticText(settingsGroup, -1, _("X (px):")), pos = (0, 2), flag = wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
         projectX = int(math.floor(float(self._get_setting("project_x", 1920))))
         self.X = wx.SpinCtrl(settingsGroup, -1, str(projectX), max = 999999, size = (125, -1))
@@ -382,7 +392,8 @@ class SettingsFrame(wx.Dialog):
         self.projected_X_mm = wx.SpinCtrlDouble(settingsGroup, -1, initial = self._get_setting("project_projected_x", 505.0), inc = 1, size = (125, -1))
         self.projected_X_mm.SetDigits(1)
         self.projected_X_mm.Bind(wx.EVT_SPINCTRLDOUBLE, self.update_projected_Xmm)
-        self.projected_X_mm.SetToolTip(_("The actual width of the entire projected image. Use the Calibrate grid to show the full size of the projected image, and measure the width at the same level where the slice will be projected onto the resin."))
+        self.projected_X_mm.SetToolTip(_("The actual width of the entire projected image. Use the Calibrate grid to show the full size of the projected image,") +
+                                       _(" and measure the width at the same level where the slice will be projected onto the resin."))
         fieldsizer.Add(self.projected_X_mm, pos = (4, 3))
 
         fieldsizer.Add(wx.StaticText(settingsGroup, -1, _("Z-Axis Speed (mm/min):")), pos = (5, 2), flag = wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
@@ -394,7 +405,6 @@ class SettingsFrame(wx.Dialog):
         fieldboxsizer.Add(fieldsizer)
 
         # Display
-
         displayGroup = wx.StaticBox(self.panel, -1, _("Display"))
         displayboxsizer = wx.StaticBoxSizer(displayGroup)
         displaysizer = wx.BoxSizer(wx.HORIZONTAL)
@@ -402,19 +412,21 @@ class SettingsFrame(wx.Dialog):
         self.fullscreen = wx.CheckBox(displayGroup, -1, _("Fullscreen"))
         self.fullscreen.Bind(wx.EVT_CHECKBOX, self.update_fullscreen)
         self.fullscreen.SetToolTip(_("Toggles the project screen to full size."))
-        displaysizer.Add(self.fullscreen, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, getSpace('staticbox'))
+        displaysizer.Add(self.fullscreen, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, get_space('staticbox'))
         displaysizer.AddStretchSpacer(1)
 
         self.calibrate = wx.CheckBox(displayGroup, -1, _("Calibrate"))
         self.calibrate.Bind(wx.EVT_CHECKBOX, self.show_calibrate)
-        self.calibrate.SetToolTip(_("Toggles the calibration grid. Each grid should be 10mmx10mm in size. Use the grid to ensure the projected size is correct. See also the help for the ProjectedX field."))
+        self.calibrate.SetToolTip(_("Toggles the calibration grid. Each grid should be 10mmx10mm in size.") +
+                                  _(" Use the grid to ensure the projected size is correct. See also the help for the ProjectedX field."))
         displaysizer.Add(self.calibrate, 0, wx.ALIGN_CENTER_VERTICAL)
         displaysizer.AddStretchSpacer(1)
 
         first_layer_boxer = wx.BoxSizer(wx.HORIZONTAL)
         self.first_layer = wx.CheckBox(displayGroup, -1, _("1st Layer"))
         self.first_layer.Bind(wx.EVT_CHECKBOX, self.show_first_layer)
-        self.first_layer.SetToolTip(_("Displays the first layer of the model. Use this to project the first layer for longer so it holds to the base. Note: this value does not affect the first layer when the \"Start\" run is started, it should be used manually."))
+        self.first_layer.SetToolTip(_("Displays the first layer of the model. Use this to project the first layer for longer so it holds to the base.") +
+                                    _(" Note: this value does not affect the first layer when the \"Start\" run is started, it should be used manually."))
 
         first_layer_boxer.Add(self.first_layer, flag = wx.ALIGN_CENTER_VERTICAL)
 
@@ -422,14 +434,14 @@ class SettingsFrame(wx.Dialog):
         self.show_first_layer_timer = wx.SpinCtrlDouble(displayGroup, -1, initial = -1, min = -1, inc = 1, size = (125, -1))
         self.show_first_layer_timer.SetDigits(1)
         self.show_first_layer_timer.SetToolTip(_("How long to display the first layer for. -1 = unlimited."))
-        first_layer_boxer.Add(self.show_first_layer_timer, flag = wx.ALIGN_CENTER_VERTICAL | wx.LEFT, border = getSpace('mini'))
+        first_layer_boxer.Add(self.show_first_layer_timer, flag = wx.ALIGN_CENTER_VERTICAL | wx.LEFT, border = get_space('mini'))
         displaysizer.Add(first_layer_boxer, 0, wx.ALIGN_CENTER_VERTICAL)
         displaysizer.AddStretchSpacer(1)
 
         self.layer_red = wx.CheckBox(displayGroup, -1, _("Red"))
         self.layer_red.Bind(wx.EVT_CHECKBOX, self.show_layer_red)
         self.layer_red.SetToolTip(_("Toggles whether the image should be red. Useful for positioning whilst resin is in the printer as it should not cause a reaction."))
-        displaysizer.Add(self.layer_red, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, getSpace('staticbox'))
+        displaysizer.Add(self.layer_red, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, get_space('staticbox'))
 
         displayboxsizer.Add(displaysizer, 1, wx.EXPAND)
 
@@ -437,7 +449,7 @@ class SettingsFrame(wx.Dialog):
         infoGroup = wx.StaticBox(self.panel, label = _("Info"))
         infosizer = wx.StaticBoxSizer(infoGroup, wx.VERTICAL)
 
-        infofieldsizer = wx.GridBagSizer(vgap = getSpace('minor'), hgap = getSpace('minor'))
+        infofieldsizer = wx.GridBagSizer(vgap = get_space('minor'), hgap = get_space('minor'))
 
         filelabel = wx.StaticText(infoGroup, -1, _("File:"))
         filelabel.SetToolTip(_("The name of the model currently loaded."))
@@ -464,7 +476,7 @@ class SettingsFrame(wx.Dialog):
         infofieldsizer.Add(self.estimated_time, pos = (3, 1), flag = wx.EXPAND)
 
         statuslabel = wx.StaticText(infoGroup, -1, _("Status:"))
-        statuslabel.SetToolTip(_("Latest activity, informational and error messages."))
+        statuslabel.SetToolTip(_("Latest activity, information and error messages."))
         infofieldsizer.Add(statuslabel, pos=(4, 0), flag = wx.ALIGN_RIGHT)
         self.statusbar = wx.StaticText(infoGroup, -1, "", style = wx.ELLIPSIZE_END)
         infofieldsizer.Add(self.statusbar, pos = (4, 1), flag = wx.EXPAND)
@@ -472,12 +484,12 @@ class SettingsFrame(wx.Dialog):
         infofieldsizer.AddGrowableCol(1)
         infosizer.Add(infofieldsizer, 1, wx.EXPAND)
 
-        #
+        # Layout
         vbox = wx.BoxSizer(wx.VERTICAL)
-        vbox.Add(buttonbox, flag = wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP | wx.BOTTOM, border = getSpace('minor'))
-        vbox.Add(fieldboxsizer, flag = wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, border = getSpace('minor'))
-        vbox.Add(displayboxsizer, flag = wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, border = getSpace('minor'))
-        vbox.Add(infosizer, flag = wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, border = getSpace('minor'))
+        vbox.Add(buttonbox, flag = wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP | wx.BOTTOM, border = get_space('minor'))
+        vbox.Add(fieldboxsizer, flag = wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, border = get_space('minor'))
+        vbox.Add(displayboxsizer, flag = wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, border = get_space('minor'))
+        vbox.Add(infosizer, flag = wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, border = get_space('minor'))
         self.panel.SetSizerAndFit(vbox)
 
         reset_button = wx.Button(self, -1, label=_("Reset"))
@@ -488,9 +500,9 @@ class SettingsFrame(wx.Dialog):
         bottom_button_sizer.Add(close_button, 0)
 
         topsizer = wx.BoxSizer(wx.VERTICAL)
-        topsizer.Add(self.panel, wx.EXPAND | wx.BOTTOM, getSpace('mini'))
+        topsizer.Add(self.panel, wx.EXPAND | wx.BOTTOM, get_space('mini'))
         topsizer.Add(wx.StaticLine(self, -1, style = wx.LI_HORIZONTAL), 0, wx.EXPAND)
-        topsizer.Add(bottom_button_sizer, 0, wx.EXPAND | wx.ALL, getSpace('stddlg-frame'))
+        topsizer.Add(bottom_button_sizer, 0, wx.EXPAND | wx.ALL, get_space('stddlg-frame'))
 
         self.Bind(wx.EVT_BUTTON, self.on_close, id=wx.ID_CLOSE)
         self.Bind(wx.EVT_CLOSE, self.on_close)
@@ -522,7 +534,7 @@ class SettingsFrame(wx.Dialog):
         if not hasattr(self, 'layers'):
             return
 
-        current_layer = int(float(self.current_layer.GetLabel()))
+        current_layer = int(self.current_layer.GetLabel())
         remaining_layers = len(self.layers[0]) - current_layer
         # 0.5 for delay between hide and rise
         estimated_time = remaining_layers * (float(self.interval.GetValue()) + float(self.pause.GetValue()) + 0.5)
@@ -596,9 +608,9 @@ class SettingsFrame(wx.Dialog):
         if not zipfile.is_zipfile(name):
             raise Exception(name + _(" is not a zip file!"))
         accepted_image_types = ['gif', 'tiff', 'jpg', 'jpeg', 'bmp', 'png']
-        zipFile = zipfile.ZipFile(name, 'r')
-        self.image_dir = tempfile.mkdtemp()
-        zipFile.extractall(self.image_dir)
+        with zipfile.ZipFile(name, 'r') as zipFile:
+            self.image_dir = tempfile.mkdtemp()
+            zipFile.extractall(self.image_dir)
         ol = []
 
         # Note: the following funky code extracts any numbers from the filenames, matches
@@ -619,10 +631,12 @@ class SettingsFrame(wx.Dialog):
 
     def load_file(self, event):
         dlg = wx.FileDialog(self, _("Open file to print"), style = wx.FD_OPEN | wx.FD_FILE_MUST_EXIST)
-        dlg.SetWildcard(_("Slic3r or Skeinforge svg files (;*.svg;*.SVG;);3DLP Zip (;*.3dlp.zip;)"))
+        # On macOS, the wildcard for *.3dlp.zip is not recognised, so it is just *.zip.
+        load_wildcard = _("Slic3r or Skeinforge SVG files") + " (*.svg)|*.svg|" + _("3DLP Zip files") + " (*.3dlp.zip)|*.zip"
+        dlg.SetWildcard(load_wildcard)
         if dlg.ShowModal() == wx.ID_OK:
             name = dlg.GetPath()
-            if not(os.path.exists(name)):
+            if not os.path.exists(name):
                 self.status.SetStatusText(_("File not found!"))
                 return
             if name.endswith(".3dlp.zip"):
@@ -630,12 +644,10 @@ class SettingsFrame(wx.Dialog):
                 layerHeight = float(self.thickness.GetValue())
             else:
                 layers = self.parse_svg(name)
-                layerHeight = float(f"{layers[1]:.2f}") # layer[1] formatted
-                # Caution: *1000000 is a special adjustment to dislpay the Slic3r 1.3.0 *.svg files correctly.
-                # layerHeight = float(f"{layers[1]*1000000:.2f}")
+                layerHeight = float(f"{layers[1]:.3f}")
                 self.thickness.SetValue(str(layerHeight))
-                self.statusbar.SetLabel(_("Layer thickness detected: %s mm") % layerHeight)
-            self.statusbar.SetLabel(_("%s layers found, total height %s mm") % (len(layers[0]), layerHeight * len(layers[0])))
+                self.statusbar.SetLabel(_("Layer thickness detected: {0:.2f} mm").format(layerHeight))
+            self.statusbar.SetLabel(_("{0} layers found, total height {1:.2f} mm").format(len(layers[0]), layerHeight * len(layers[0])))
             self.layers = layers
             self.set_total_layers(len(layers[0]))
             self.set_current_layer(0)
@@ -727,7 +739,8 @@ class SettingsFrame(wx.Dialog):
                 def unpresent_first_layer():
                     self.display_frame.clear_layer()
                     self.first_layer.SetValue(False)
-                # AGE2023-04-19 Python 3.10 expects delay in milliseconds as integer value instead of float. Convert float value to int
+                # AGE2023-04-19 Python 3.10 expects delay in milliseconds as
+                # integer value instead of float. Convert float value to int
                 wx.CallLater(int(self.show_first_layer_timer.GetValue() * 1000), unpresent_first_layer)
 
     def update_offset(self, event):
@@ -747,21 +760,20 @@ class SettingsFrame(wx.Dialog):
 
     def update_thickness(self, event):
         layer = self.thickness.GetValue()
-
         if ',' in layer:
-            self.statusbar.SetLabel(_("'Layer' contains a comma, please use a point for decimal values."))
-            self.Layout() # Layout() is needed to ellipsize possible overlength status
-            return False
-
+            # Decimal point cannot be a comma
+            layer = layer.replace(',', '.')
+            self.thickness.SetValue(layer)
+            self.thickness.SetInsertionPointEnd()
         try:
             float(layer)
         except ValueError:
             self.statusbar.SetLabel(_("Unrecognized number in 'Layer': %s") % layer)
-            return False
-        else:
-            self.statusbar.SetLabel("")
-            self._set_setting('project_layer', float(layer))
-            self.refresh_display(event)
+            return
+
+        self.statusbar.SetLabel("")
+        self._set_setting('project_layer', float(layer))
+        self.refresh_display(event)
 
     def update_projected_Xmm(self, event):
         self._set_setting('project_projected_x', self.projected_X_mm.GetValue())
@@ -775,43 +787,41 @@ class SettingsFrame(wx.Dialog):
 
     def update_interval(self, event):
         interval = self.interval.GetValue()
-
         if ',' in interval:
-            self.statusbar.SetLabel(_("'Exposure' contains a comma, please use a point for decimal values."))
-            self.Layout() # Layout() is needed to ellipsize possible overlength status
-            return False
-
+            # Decimal point cannot be a comma
+            interval = interval.replace(',', '.')
+            self.interval.SetValue(interval)
+            self.interval.SetInsertionPointEnd()
         try:
             float(interval)
         except ValueError:
             self.statusbar.SetLabel(_("Unrecognized number in 'Exposure': %s") % interval)
-            return False
-        else:
-            self.statusbar.SetLabel("")
-            self.display_frame.interval = float(interval)
-            self._set_setting('project_interval', float(self.interval.GetValue()))
-            self.set_estimated_time()
-            self.refresh_display(event)
+            return
+
+        self.statusbar.SetLabel("")
+        self.display_frame.interval = float(interval)
+        self._set_setting('project_interval', float(self.interval.GetValue()))
+        self.set_estimated_time()
+        self.refresh_display(event)
 
     def update_pause(self, event):
         pause = self.pause.GetValue()
-
         if ',' in pause:
-            self.statusbar.SetLabel(_("'Blank' contains a comma, please use a point for decimal values."))
-            self.Layout() # Layout() is needed to ellipsize possible overlength status
-            return False
-
+            # Decimal point cannot be a comma
+            pause = pause.replace(',', '.')
+            self.pause.SetValue(pause)
+            self.pause.SetInsertionPointEnd()
         try:
             float(pause)
         except ValueError:
             self.statusbar.SetLabel(_("Unrecognized number in 'Blank': %s") % pause)
-            return False
-        else:
-            self.statusbar.SetLabel("")
-            self.display_frame.pause = float(pause)
-            self._set_setting('project_pause', float(pause))
-            self.set_estimated_time()
-            self.refresh_display(event)
+            return
+
+        self.statusbar.SetLabel("")
+        self.display_frame.pause = float(pause)
+        self._set_setting('project_pause', float(pause))
+        self.set_estimated_time()
+        self.refresh_display(event)
 
     def update_overshoot(self, event):
         overshoot = float(self.overshoot.GetValue())
@@ -866,7 +876,7 @@ class SettingsFrame(wx.Dialog):
             self.statusbar.SetLabel(_("No model loaded!"))
             return
         self.statusbar.SetLabel(_("Starting..."))
-        self.pause_button.SetLabel(self.getButtonLabel('pause'))
+        self.pause_button.SetLabel(self.get_btn_label('pause'))
         self.pause_button.Enable()
         self.stop_button.Enable()
         self.set_current_layer(0)
@@ -894,7 +904,7 @@ class SettingsFrame(wx.Dialog):
     def stop_present(self, event):
         self.statusbar.SetLabel(_("Stopping..."))
         self.display_frame.running = False
-        self.pause_button.SetLabel(self.getButtonLabel('pause'))
+        self.pause_button.SetLabel(self.get_btn_label('pause'))
         self.set_current_layer(0)
         self.present_button.Enable()
         self.pause_button.Disable()
@@ -902,13 +912,13 @@ class SettingsFrame(wx.Dialog):
         self.statusbar.SetLabel(_("Stop"))
 
     def pause_present(self, event):
-        if self.pause_button.GetLabel() == self.getButtonLabel('pause'):
-            self.statusbar.SetLabel(self.getButtonLabel('pause'))
-            self.pause_button.SetLabel(self.getButtonLabel('continue'))
+        if self.pause_button.GetLabel() == self.get_btn_label('pause'):
+            self.statusbar.SetLabel(self.get_btn_label('pause'))
+            self.pause_button.SetLabel(self.get_btn_label('continue'))
             self.display_frame.running = False
         else:
-            self.statusbar.SetLabel(self.getButtonLabel('continue'))
-            self.pause_button.SetLabel(self.getButtonLabel('pause'))
+            self.statusbar.SetLabel(self.get_btn_label('continue'))
+            self.pause_button.SetLabel(self.get_btn_label('pause'))
             self.display_frame.running = True
             self.display_frame.next_img()
 
@@ -918,52 +928,53 @@ class SettingsFrame(wx.Dialog):
             self.display_frame.Destroy()
         self.Destroy()
 
-    def getButtonLabel(self, value):
+    def get_btn_label(self, value):
         # This method simplifies translation of the button label
         if value == 'pause':
             return _("Pause")
-        elif value == 'continue':
+
+        if value == 'continue':
             return _("Continue")
-        else:
-            return "ErrorButtonLabel"
-        
+
+        return ValueError(f"No button label for '{value}'")
+
     def reset_all(self, event):
         # Ask confirmation for deleting
         reset_dialog = wx.MessageDialog(self,
-            message = _("Are you sure you want to reset all the settings to the defaults?\nBe aware that the defaults are not guaranteed to work well with your machine."),
-            caption = _("Reset ProjectLayer Settings"),
-            style = wx.YES_NO | wx.ICON_EXCLAMATION)
+            message = _("Are you sure you want to reset all the settings to the defaults?") + "\n" +
+            _("Be aware that the defaults are not guaranteed to work well with your machine."),
+            caption = _("Reset ProjectLayer Settings"), style = wx.YES_NO | wx.ICON_EXCLAMATION)
 
         if reset_dialog.ShowModal() == wx.ID_YES:
             # Reset all settings
             std_settings = [
-                [ self.thickness, "0.1", self.update_thickness],
-                [ self.interval, "2.0", self.update_interval],
-                [ self.pause, "2.5", self.update_pause],
-                [ self.scale, 1.0, self.update_scale],
-                [ self.overshoot, 3.0, self.update_overshoot],
-                [ self.prelift_gcode, "", self.update_prelift_gcode],
+                [self.thickness, "0.1", self.update_thickness],
+                [self.interval, "2.0", self.update_interval],
+                [self.pause, "2.5", self.update_pause],
+                [self.scale, 1.0, self.update_scale],
+                [self.overshoot, 3.0, self.update_overshoot],
+                [self.prelift_gcode, "", self.update_prelift_gcode],
 
-                [ self.X, 1024, self.update_resolution],
-                [ self.Y, 768, self.update_resolution],
-                [ self.offset_X, 0, self.update_offset],
-                [ self.offset_Y, 0, self.update_offset],
-                [ self.projected_X_mm, 100.0, self.update_projected_Xmm],
-                [ self.z_axis_rate, 200, self.update_z_axis_rate],
-                [ self.postlift_gcode, "", self.update_postlift_gcode],
-                
-                [ self.fullscreen, False, self.update_fullscreen],
-                [ self.calibrate, False, self.show_calibrate],
-                [ self.first_layer, False, self.show_first_layer],
-                [ self.show_first_layer_timer, -1.0, self.show_first_layer_timer],
-                [ self.layer_red, False, self.show_layer_red]
+                [self.X, 1024, self.update_resolution],
+                [self.Y, 768, self.update_resolution],
+                [self.offset_X, 0, self.update_offset],
+                [self.offset_Y, 0, self.update_offset],
+                [self.projected_X_mm, 100.0, self.update_projected_Xmm],
+                [self.z_axis_rate, 200, self.update_z_axis_rate],
+                [self.postlift_gcode, "", self.update_postlift_gcode],
+
+                [self.fullscreen, False, self.update_fullscreen],
+                [self.calibrate, False, self.show_calibrate],
+                [self.first_layer, False, self.show_first_layer],
+                [self.show_first_layer_timer, -1.0, self.show_first_layer_timer],
+                [self.layer_red, False, self.show_layer_red]
             ]
 
             for setting in std_settings:
                 self.reset_setting(event, setting[0], setting[1], setting[2])
 
-            # Direction is not in the std_settings list because it can't be set with SetValue but SetSelection instead
-            #[ self.direction, 0, self.update_direction]
+            # Direction is not in the std_settings list because it can't be set
+            # with SetValue but SetSelection instead
             if not 0 == self.direction.GetSelection():
                 self.direction.SetSelection(0)
                 self.update_direction(event)
@@ -971,8 +982,8 @@ class SettingsFrame(wx.Dialog):
             self.filename.SetLabel("")
             self.total_layers.SetLabel("")
             self.current_layer.SetLabel("0")
-            self.estimated_time.SetLabel("")        
-            self.statusbar.SetLabel(_("ProjectLayer Settings Reset"))
+            self.estimated_time.SetLabel("")
+            self.statusbar.SetLabel(_("ProjectLayer Settings reset"))
 
     def reset_setting(self, event, name, value, update_function):
         # First check if the user actually changed the setting
@@ -980,6 +991,7 @@ class SettingsFrame(wx.Dialog):
             # If so, set it back and invoke the update_function to save the value
             name.SetValue(value)
             update_function(event)
+
 
 if __name__ == "__main__":
     a = wx.App()

--- a/printrun/pronterface.py
+++ b/printrun/pronterface.py
@@ -49,7 +49,7 @@ except:
     logging.error(_("WX >= 4 is not installed. This program requires WX >= 4 to run."))
     raise
 
-from .gui.widgets import SpecialButton, MacroEditor, PronterOptions, ButtonEdit, getSpace
+from .gui.widgets import SpecialButton, MacroEditor, PronterOptions, ButtonEdit, get_space
 
 winsize = (800, 500)
 layerindex = 0
@@ -60,6 +60,7 @@ pronterface_quitting = False
 
 class PronterfaceQuitException(Exception):
     pass
+
 
 from .gui import MainWindow
 from .settings import wxSetting, HiddenSetting, StringSetting, SpinSetting, \
@@ -142,8 +143,8 @@ class PronterWindow(MainWindow, pronsole.pronsole):
         self.ui_ready = False
         self._add_settings(size)
 
-        self.pauseScript = None #"pause.gcode"
-        self.endScript = None #"end.gcode"
+        self.pauseScript = None  # "pause.gcode"
+        self.endScript = None  # "end.gcode"
 
         self.filename = filename
 
@@ -267,7 +268,7 @@ class PronterWindow(MainWindow, pronsole.pronsole):
             logcontent = self.logbox.GetValue()
             self.menustrip.SetMenus([])
             if len(self.commandbox.history):
-                #save current command box history
+                # save current command box history
                 if not os.path.exists(self.history_file):
                     if not os.path.exists(self.cache_dir):
                         os.makedirs(self.cache_dir)
@@ -355,7 +356,7 @@ class PronterWindow(MainWindow, pronsole.pronsole):
             keys = {'B': self.btemp, 'H': self.htemp, 'J': self.xyb, 'S': self.commandbox,
                 'V': self.gviz}
             widget = keys.get(ch)
-            #ignore Alt+(S, H), so it can open Settings, Help menu
+            # ignore Alt+(S, H), so it can open Settings, Help menu
             if widget and (ch not in 'SH' or not event.AltDown()) \
                 and not (event.ControlDown() and ch == 'V'
                         and event.EventObject is self.commandbox):
@@ -369,7 +370,7 @@ class PronterWindow(MainWindow, pronsole.pronsole):
                             (self.pausebtn, self.pause), \
                             (self.printbtn, self.printfile)
                 for ctl, cb in candidates:
-                    match = ('&' + ch) in ctl.Label.upper()
+                    match = '&' + ch in ctl.Label.upper()
                     handled = in_toolbar and match
                     if handled:
                         break
@@ -389,16 +390,18 @@ class PronterWindow(MainWindow, pronsole.pronsole):
 
     def kill(self, e=None):
         if len(self.commandbox.history):
-                #save current command box history
-                history = (self.history_file)
-                if not os.path.exists(history):
-                    if not os.path.exists(self.cache_dir):
-                        os.makedirs(self.cache_dir)
-                write_history_to(history,self.commandbox.history)
+            # save current command box history
+            history = self.history_file
+            if not os.path.exists(history):
+                if not os.path.exists(self.cache_dir):
+                    os.makedirs(self.cache_dir)
+            write_history_to(history, self.commandbox.history)
+
         if self.p.printing or self.p.paused:
             dlg = wx.MessageDialog(self, _("Print in progress ! Are you really sure you want to quit ?"), _("Exit"), wx.YES_NO | wx.ICON_WARNING)
             if dlg.ShowModal() == wx.ID_NO:
                 return
+
         pronsole.pronsole.kill(self)
         global pronterface_quitting
         pronterface_quitting = True
@@ -592,7 +595,7 @@ class PronterWindow(MainWindow, pronsole.pronsole):
                 if dir == 1:
                     # do not cycle top => bottom
                     return
-                #save unsent command before going back
+                # save unsent command before going back
                 self.appendCommandHistory()
             self.commandbox.histindex = max(0, min(self.commandbox.histindex + dir, len(self.commandbox.history)))
             self.commandbox.Value = (self.commandbox.history[self.commandbox.histindex]
@@ -786,7 +789,7 @@ class PronterWindow(MainWindow, pronsole.pronsole):
     def set_verbose_communications(self, e):
         self.p.loud = e.IsChecked()
 
-    def set_autoscrolldisable(self,e):
+    def set_autoscrolldisable(self, e):
         self.autoscrolldisable = e.IsChecked()
 
     def sendline(self, e):
@@ -966,7 +969,7 @@ Printrun. If not, see <http://www.gnu.org/licenses/>."""
         info.AddDeveloper('Maja M. @SparkyCola (code)')
         info.AddDeveloper('Francesco Santini @fsantini (code)')
         info.AddDeveloper('Cristopher Olah @colah (code)')
-        
+
         info.AddDeveloper('Jeremy Kajikawa (code)')
         info.AddDeveloper('Markus Hitter (code)')
         info.AddDeveloper('SkateBoss (code)')
@@ -1054,10 +1057,10 @@ Printrun. If not, see <http://www.gnu.org/licenses/>."""
         info.AddDeveloper('l4nce0 (code)')
         info.AddDeveloper('palob (code)')
         info.AddDeveloper('russ (code)')
-        
+
         info.AddArtist('Ahmet Cem TURAN @ahmetcemturan (icons, code)')
         info.AddArtist('Duane Johnson (code,graphics)')
-        
+
         info.AddTranslator('freddii (German translation)')
         info.AddTranslator('Christian Metzen @metzench (German translation)')
         info.AddTranslator('Cyril Laguilhon-Debat (French translation)')
@@ -1066,7 +1069,7 @@ Printrun. If not, see <http://www.gnu.org/licenses/>."""
         info.AddTranslator('Ruben Lubbes (NL translation)')
         info.AddTranslator('aboobed (Arabic translation)')
         info.AddTranslator('Alessandro Ranellucci @alranel (Italian translation)')
-        
+
         wx.adv.AboutBox(info)
 
     #  --------------------------------------------------------------
@@ -1083,7 +1086,7 @@ Printrun. If not, see <http://www.gnu.org/licenses/>."""
         self.settings._add(SpinSetting("printer_progress_update_interval", 10., 0, 120, _("Printer progress update interval"), _("Interval in which pronterface sends the progress to the printer if enabled, in seconds"), "Printer"))
         self.settings._add(BooleanSetting("cutting_as_extrusion", True, _("Display cutting moves"), _("Show moves where spindle is active as printing moves"), "Printer"))
         self.settings._add(ComboSetting("uimode", _("Standard"), [_("Standard"), _("Compact"), ], _("Interface mode"), _("Standard interface is a one-page, three columns layout with controls/visualization/log\nCompact mode is a one-page, two columns layout with controls + log/visualization"), "UI"), self.reload_ui)
-        #self.settings._add(ComboSetting("uimode", _("Standard"), [_("Standard"), _("Compact"), _("Tabbed"), _("Tabbed with platers")], _("Interface mode"), _("Standard interface is a one-page, three columns layout with controls/visualization/log\nCompact mode is a one-page, two columns layout with controls + log/visualization"), "UI"), self.reload_ui)
+        # self.settings._add(ComboSetting("uimode", _("Standard"), [_("Standard"), _("Compact"), _("Tabbed"), _("Tabbed with platers")], _("Interface mode"), _("Standard interface is a one-page, three columns layout with controls/visualization/log\nCompact mode is a one-page, two columns layout with controls + log/visualization"), "UI"), self.reload_ui)
         self.settings._add(ComboSetting("controlsmode", _("Standard"), (_("Standard"), _("Mini"), ), _("Controls mode"), _("Standard controls include all controls needed for printer setup and calibration, while Mini controls are limited to the ones needed for daily printing"), "UI"), self.reload_ui)
         self.settings._add(BooleanSetting("slic3rintegration", False, _("Enable Slic3r integration"), _("Add a menu to select Slic3r profiles directly from Pronterface"), "UI"), self.reload_ui)
         self.settings._add(BooleanSetting("slic3rupdate", False, _("Update Slic3r default presets"), _("When selecting a profile in Slic3r integration menu, also save it as the default Slic3r preset"), "UI"))
@@ -1271,11 +1274,11 @@ Printrun. If not, see <http://www.gnu.org/licenses/>."""
                 if self.settings.display_progress_on_printer and time.time() - self.printer_progress_time >= self.settings.printer_progress_update_interval:
                     self.printer_progress_time = time.time()
                     printer_progress_string = "M117 " + str(round(100 * float(self.p.queueindex) / len(self.p.mainqueue), 2)) + "% Est " + format_duration(secondsremain)
-                    #":" seems to be some kind of separator for G-CODE"
+                    # ":" seems to be some kind of separator for G-CODE"
                     self.p.send_now(printer_progress_string.replace(":", "."))
                     if len(printer_progress_string) > 25:
                         logging.info("Warning: The print progress message might be too long to be displayed properly")
-                    #13 chars for up to 99h est.
+                    # 13 chars for up to 99h est.
         elif self.loading_gcode:
             status_string = self.loading_gcode_message
         wx.CallAfter(self.statusbar.SetStatusText, status_string)
@@ -1544,7 +1547,7 @@ Printrun. If not, see <http://www.gnu.org/licenses/>."""
     def slice_func(self):
         try:
             output_filename = self.model_to_gcode_filename(self.filename)
-            pararray = prepare_command(self.settings.slicecommandpath+self.settings.slicecommand,
+            pararray = prepare_command(self.settings.slicecommandpath + self.settings.slicecommand,
                                        {"$s": self.filename, "$o": output_filename})
             if self.settings.slic3rintegration:
                 for cat, config in self.slic3r_configs.items():
@@ -1623,9 +1626,9 @@ Printrun. If not, see <http://www.gnu.org/licenses/>."""
             dlg = wx.FileDialog(self, _("Open file to print"), basedir, style = wx.FD_OPEN | wx.FD_FILE_MUST_EXIST)
             dlg.SetWildcard(_("OBJ, STL, and GCODE files (*.gcode;*.gco;*.g;*.stl;*.STL;*.obj;*.OBJ)|*.gcode;*.gco;*.g;*.stl;*.STL;*.obj;*.OBJ|GCODE files (*.gcode;*.gco;*.g)|*.gcode;*.gco;*.g|OBJ, STL files (*.stl;*.STL;*.obj;*.OBJ)|*.stl;*.STL;*.obj;*.OBJ|All Files (*.*)|*.*"))
             try:
-              dlg.SetFilterIndex(self.settings.last_file_filter)
+                dlg.SetFilterIndex(self.settings.last_file_filter)
             except:
-              pass
+                pass
         if filename or dlg.ShowModal() == wx.ID_OK:
             if filename:
                 name = filename
@@ -1678,7 +1681,7 @@ Printrun. If not, see <http://www.gnu.org/licenses/>."""
             return
         except Exception as e:
             self.log(str(e))
-            wx.CallAfter(self.post_gcode_load,False,True)
+            wx.CallAfter(self.post_gcode_load, False, True)
             return
         wx.CallAfter(self.post_gcode_load)
 
@@ -1755,19 +1758,19 @@ Printrun. If not, see <http://www.gnu.org/licenses/>."""
 
         if len(gcode.filament_length_multi) > 1:
             for i in enumerate(gcode.filament_length_multi):
-                if self.spool_manager.getSpoolName(i[0]) == None:
+                if self.spool_manager.getSpoolName(i[0]) is None:
                     logging.info("- Extruder %d: %0.02fmm" % (i[0], i[1]))
                 else:
                     logging.info(("- Extruder %d: %0.02fmm" % (i[0], i[1]) +
                         " from spool '%s' (%.2fmm will remain)" %
                         (self.spool_manager.getSpoolName(i[0]),
                         self.calculate_remaining_filament(i[1], i[0]))))
-        elif self.spool_manager.getSpoolName(0) != None:
-                self.log(
-                    _("Using spool '%s' (%s of filament will remain)") %
-                    (self.spool_manager.getSpoolName(0),
-                    format_length(self.calculate_remaining_filament(
-                        gcode.filament_length, 0))))
+        elif self.spool_manager.getSpoolName(0) is not None:
+            self.log(
+                _("Using spool '%s' (%s of filament will remain)") %
+                (self.spool_manager.getSpoolName(0),
+                format_length(self.calculate_remaining_filament(
+                    gcode.filament_length, 0))))
 
         self.log(_("The print goes:"))
         self.log(_("- from %.2f mm to %.2f mm in X and is %.2f mm wide") % (gcode.xmin, gcode.xmax, gcode.width))
@@ -1911,10 +1914,10 @@ Printrun. If not, see <http://www.gnu.org/licenses/>."""
                 if self.display_gauges: wx.CallAfter(self.bedtgauge.SetTarget, temp)
                 if self.display_graph: wx.CallAfter(self.graph.SetBedTargetTemperature, temp)
         elif gline.command in ["M106"]:
-            gline_s=gcoder.S(gline)
-            fanpow=255
+            gline_s = gcoder.S(gline)
+            fanpow = 255
             if gline_s is not None:
-                fanpow=gline_s
+                fanpow = gline_s
             if self.display_graph: wx.CallAfter(self.graph.SetFanPower, fanpow)
         elif gline.command in ["M107"]:
             if self.display_graph: wx.CallAfter(self.graph.SetFanPower, 0)
@@ -2088,7 +2091,7 @@ Printrun. If not, see <http://www.gnu.org/licenses/>."""
             self.recvlisteners.remove(self.listfiles)
             wx.CallAfter(self.filesloaded)
         elif self.sdlisting:
-            self.sdfiles.append(re.sub(" \d+$","",line.strip().lower()))
+            self.sdfiles.append(re.sub(" \d+$", "", line.strip().lower()))  # NOQA
 
     def waitforsdresponse(self, l):
         if "file.open failed" in l:
@@ -2297,9 +2300,9 @@ Printrun. If not, see <http://www.gnu.org/licenses/>."""
                     return
             if not hasattr(self, "dragging"):
                 # init dragging of the custom button
-                if hasattr(obj, "custombutton") and (not hasattr(obj,"properties") or obj.properties is not None):
+                if hasattr(obj, "custombutton") and (not hasattr(obj, "properties") or obj.properties is not None):
                     for b in self.custombuttons_widgets:
-                        if not hasattr(b,"properties") or b.properties is None:
+                        if not hasattr(b, "properties") or b.properties is None:
                             b.Enable()
                             b.SetLabel("")
                             b.SetFont(wx.Font(10, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL))
@@ -2361,7 +2364,7 @@ Printrun. If not, see <http://www.gnu.org/licenses/>."""
                 if b.GetScreenRect().Contains(scrpos):
                     dst = b
                     break
-            if dst is not None and hasattr(dst,"custombutton"):
+            if dst is not None and hasattr(dst, "custombutton"):
                 src_i = src.custombutton
                 dst_i = dst.custombutton
                 self.custombuttons[src_i], self.custombuttons[dst_i] = self.custombuttons[dst_i], self.custombuttons[src_i]
@@ -2437,13 +2440,13 @@ Printrun. If not, see <http://www.gnu.org/licenses/>."""
         ## Group the text and the name control box horizontally
         topsizer = wx.BoxSizer(wx.VERTICAL)
         textsizer.Add(text, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_LEFT)
-        textsizer.AddSpacer(getSpace('minor'))
+        textsizer.AddSpacer(get_space('minor'))
         textsizer.Add(namectrl, 1, wx.EXPAND | wx.ALIGN_LEFT)
         panel.SetSizer(textsizer)
-        topsizer.Add(panel,1, wx.ALL, getSpace('major'))
+        topsizer.Add(panel, 1, wx.ALL, get_space('major'))
         ## Group everything vertically
         topsizer.Add(wx.StaticLine(dialog, -1, style = wx.LI_HORIZONTAL), 0, wx.EXPAND)
-        topsizer.Add(dialog.CreateButtonSizer(wx.OK | wx.CANCEL), 0, wx.ALIGN_RIGHT | wx.ALL, getSpace('stddlg'))
+        topsizer.Add(dialog.CreateButtonSizer(wx.OK | wx.CANCEL), 0, wx.ALIGN_RIGHT | wx.ALL, get_space('stddlg'))
         dialog.SetSizer(topsizer)
         topsizer.Fit(dialog)
         dialog.CentreOnParent()
@@ -2503,11 +2506,11 @@ Printrun. If not, see <http://www.gnu.org/licenses/>."""
             self.slic3r_configpath = configpath
             configfile = os.path.join(configpath, "slic3r.ini")
         if not os.path.exists(configfile):
-            self.settings.slic3rintegration=False;
+            self.settings.slic3rintegration = False
             return
         self.app.SetAppName(orig_appname)
         config = self.read_slic3r_config(configfile)
-        version = config.get("dummy", "version") # Slic3r version
+        version = config.get("dummy", "version")  # Slic3r version
         self.slic3r_configs = {}
         for cat in menus:
             menu = menus[cat]
@@ -2516,7 +2519,8 @@ Printrun. If not, see <http://www.gnu.org/licenses/>."""
             try:
                 preset = config.get("presets", cat)
                 # Starting from Slic3r 1.3.0, preset names have no extension
-                if version.split(".") >= ["1","3","0"]: preset += ".ini"
+                if version.split(".") >= ["1", "3", "0"]:
+                    preset += ".ini"
                 self.slic3r_configs[cat] = preset
             except:
                 preset = None
@@ -2558,10 +2562,10 @@ Printrun. If not, see <http://www.gnu.org/licenses/>."""
         self.slic3r_configs[cat] = file
         if self.settings.slic3rupdate:
             config = self.read_slic3r_config(configfile)
-            version = config.get("dummy", "version") # Slic3r version
+            version = config.get("dummy", "version")  # Slic3r version
             preset = os.path.basename(file)
             # Starting from Slic3r 1.3.0, preset names have no extension
-            if version.split(".") >= ["1","3","0"]:
+            if version.split(".") >= ["1", "3", "0"]:
                 preset = os.path.splitext(preset)[0]
             config.set("presets", cat, preset)
             f = StringIO.StringIO()
@@ -2577,7 +2581,7 @@ class PronterApp(wx.App):
     mainwindow = None
 
     def __init__(self, *args, **kwargs):
-        super(PronterApp, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.SetAppName("Pronterface")
         self.locale = wx.Locale(wx.Locale.GetSystemLanguage())
         self.mainwindow = PronterWindow(self)

--- a/printrun/spoolmanager/spoolmanager_gui.py
+++ b/printrun/spoolmanager/spoolmanager_gui.py
@@ -88,15 +88,15 @@ class SpoolManagerMainWindow(wx.Frame):
 
         ## Group the buttons with the spool list
         self.list_sizer = wx.StaticBoxSizer(wx.HORIZONTAL, self.panel, label = _("Spool List"))
-        self.list_sizer.Add(self.spool_list, 1, wx.EXPAND)
-        self.list_sizer.Add(self.list_button_sizer, 0, wx.ALIGN_TOP)
+        self.list_sizer.Add(self.spool_list, 1, wx.EXPAND | wx.ALL, getSpace('staticbox'))
+        self.list_sizer.Add(self.list_button_sizer, 0, wx.ALIGN_TOP | wx.ALL, getSpace('staticbox'))
 
         ## Layout the whole thing
         widgetsizer = wx.BoxSizer(wx.VERTICAL)
         widgetsizer.Add(self.list_sizer, 1, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, getSpace('minor'))
         widgetsizer.Add(self.current_spools_dialog, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, getSpace('minor'))
         widgetsizer.Add(wx.StaticLine(self.panel, -1, style = wx.LI_HORIZONTAL), 0, wx.EXPAND)
-        widgetsizer.Add(self.bottom_button_sizer, 0, wx.EXPAND | wx.ALL, getSpace('major'))
+        widgetsizer.Add(self.bottom_button_sizer, 0, wx.EXPAND | wx.ALL, getSpace('stddlg-frame'))
 
         ## Make sure the frame has the right size when it open, but is still resizeable
         self.panel.SetSizer(widgetsizer)      
@@ -236,7 +236,7 @@ class SpoolListView(wx.ListView):
     def onResizeList(self, event):
         list_size = self.GetSize()
         self.SetColumnWidth(1, -2)
-        filament_column_width = self.GetColumnWidth(1) + 16
+        filament_column_width = self.GetColumnWidth(1)
         self.SetColumnWidth(col = 0,
                             width = list_size.width - filament_column_width)
         event.Skip()
@@ -307,11 +307,11 @@ class CurrentSpoolDialog(wx.Panel):
                 wx.FIXED_MINSIZE | wx.ALIGN_CENTER)
 
             dialog_sizer.append(wx.StaticBoxSizer(wx.HORIZONTAL, self, label = _("Spool for Extruder %d:") % i))
-            dialog_sizer[i].Add(textlabel, 0, wx.ALIGN_TOP)
+            dialog_sizer[i].Add(textlabel, 0, wx.ALIGN_TOP | wx.ALL, getSpace('staticbox'))
+            dialog_sizer[i].AddSpacer(getSpace('minor'))
+            dialog_sizer[i].Add(self.extruder_dialog[i], 1, wx.ALIGN_TOP | wx.TOP, getSpace('staticbox'))
             dialog_sizer[i].AddSpacer(getSpace('major'))
-            dialog_sizer[i].Add(self.extruder_dialog[i], 1, wx.ALIGN_TOP)
-            dialog_sizer[i].AddSpacer(getSpace('major'))
-            dialog_sizer[i].Add(button_sizer[i], 0, wx.EXPAND)
+            dialog_sizer[i].Add(button_sizer[i], 0, wx.EXPAND | wx.RIGHT, getSpace('staticbox'))
 
             csd_sizer.Add(dialog_sizer[i], 0, wx.EXPAND | wx.TOP, getSpace('minor'))
 
@@ -562,27 +562,27 @@ class SpoolManagerEditWindow(wx.Dialog):
         self.length_field.SetMinSize((minwidth, -1))
         
         # Generate the buttons
+        button_min_width = self.GetTextExtent('  +000.0  ').width
         self.minus3_button = wx.Button(self,
-            label = str(self.quantities[0]), style = wx.BU_EXACTFIT)
+            label = str(self.quantities[0]))
         self.minus2_button = wx.Button(self,
-            label = str(self.quantities[1]), style = wx.BU_EXACTFIT)
+            label = str(self.quantities[1]))
         self.minus1_button = wx.Button(self,
-            label = str(self.quantities[2]), style = wx.BU_EXACTFIT)
+            label = str(self.quantities[2]))
 
         self.plus1_button = wx.Button(self,
-            label = "+" + str(self.quantities[3]), style = wx.BU_EXACTFIT)
+            label = "+" + str(self.quantities[3]))
         self.plus2_button = wx.Button(self,
-            label = "+" + str(self.quantities[4]), style = wx.BU_EXACTFIT)
+            label = "+" + str(self.quantities[4]))
         self.plus3_button = wx.Button(self,
-            label = "+" + str(self.quantities[5]), style = wx.BU_EXACTFIT)
+            label = "+" + str(self.quantities[5]))
         
-        button_min_width = self.GetTextExtent(' +000.0 ').width
-        self.minus1_button.SetMinSize((button_min_width, -1))
-        self.minus2_button.SetMinSize((button_min_width, -1))
-        self.minus3_button.SetMinSize((button_min_width, -1))
-        self.plus1_button.SetMinSize((button_min_width, -1))
-        self.plus2_button.SetMinSize((button_min_width, -1))
-        self.plus3_button.SetMinSize((button_min_width, -1))
+        self.minus3_button.SetSize((button_min_width, -1))
+        self.minus2_button.SetSize((button_min_width, -1))
+        self.minus1_button.SetSize((button_min_width, -1))
+        self.plus1_button.SetSize((button_min_width, -1))
+        self.plus2_button.SetSize((button_min_width, -1))
+        self.plus3_button.SetSize((button_min_width, -1))
 
         # "Program" the length buttons
         self.minus3_button.Bind(wx.EVT_BUTTON, self.changeLength)
@@ -605,18 +605,18 @@ class SpoolManagerEditWindow(wx.Dialog):
         ## Group the length field and its correspondent buttons             
         self.btn_sizer = wx.StaticBoxSizer(wx.HORIZONTAL, self)
         self.btn_sizer.Add(self.minus3_button, 0,
-                              wx.FIXED_MINSIZE | wx.ALIGN_CENTER | wx.RIGHT, getSpace('mini'))
+                              wx.FIXED_MINSIZE | wx.ALIGN_CENTER | wx.LEFT | wx.TOP | wx.BOTTOM, getSpace('staticbox'))
         self.btn_sizer.Add(self.minus2_button, 0,
-                              wx.FIXED_MINSIZE | wx.ALIGN_CENTER | wx.RIGHT, getSpace('mini'))
+                              wx.FIXED_MINSIZE | wx.ALIGN_CENTER | wx.LEFT | wx.RIGHT, getSpace('mini'))
         self.btn_sizer.Add(self.minus1_button, 0,
                               wx.FIXED_MINSIZE | wx.ALIGN_CENTER | wx.RIGHT, getSpace('mini'))
         self.btn_sizer.AddSpacer(getSpace('major'))
         self.btn_sizer.Add(self.plus1_button, 0,
                               wx.FIXED_MINSIZE | wx.ALIGN_CENTER | wx.LEFT, getSpace('mini'))
         self.btn_sizer.Add(self.plus2_button, 0,
-                              wx.FIXED_MINSIZE | wx.ALIGN_CENTER | wx.LEFT, getSpace('mini'))
+                              wx.FIXED_MINSIZE | wx.ALIGN_CENTER | wx.LEFT | wx.RIGHT, getSpace('mini'))
         self.btn_sizer.Add(self.plus3_button, 0,
-                              wx.FIXED_MINSIZE | wx.ALIGN_CENTER | wx.LEFT, getSpace('mini'))
+                              wx.FIXED_MINSIZE | wx.ALIGN_CENTER | wx.RIGHT, getSpace('staticbox'))
 
         ## Group the bottom buttons
         self.bottom_buttons_sizer = wx.StdDialogButtonSizer()

--- a/printrun/spoolmanager/spoolmanager_gui.py
+++ b/printrun/spoolmanager/spoolmanager_gui.py
@@ -17,6 +17,7 @@
 
 import wx
 from . import spoolmanager
+from printrun.gui.widgets import getSpace
 
 class SpoolManagerMainWindow(wx.Frame):
     """
@@ -28,8 +29,8 @@ class SpoolManagerMainWindow(wx.Frame):
 
     def __init__(self, parent, spool_manager):
         wx.Frame.__init__(self, parent,
-            title = "Spool Manager",
-            style = wx.DEFAULT_FRAME_STYLE | wx.FRAME_FLOAT_ON_PARENT)
+            title = _("Spool Manager"),
+            style = wx.DEFAULT_FRAME_STYLE)
 
         self.statusbar = self.CreateStatusBar()
 
@@ -48,38 +49,45 @@ class SpoolManagerMainWindow(wx.Frame):
 
         # Generate the buttons
         self.new_button = wx.Button(self, wx.ID_ADD)
-        self.new_button.SetToolTip("Add a new spool")
+        self.new_button.SetToolTip(_("Add a new spool"))
         self.edit_button = wx.Button(self, wx.ID_EDIT)
-        self.edit_button.SetToolTip("Edit the selected spool")
+        self.edit_button.SetToolTip(_("Edit the selected spool"))
         self.delete_button = wx.Button(self, wx.ID_DELETE)
-        self.delete_button.SetToolTip("Delete the selected spool")
+        self.delete_button.SetToolTip(_("Delete the selected spool"))
+        
+        self.close_button = wx.Button(self, wx.ID_CLOSE)
 
         # "Program" the buttons
         self.new_button.Bind(wx.EVT_BUTTON, self.onClickAdd)
         self.edit_button.Bind(wx.EVT_BUTTON, self.onClickEdit)
         self.delete_button.Bind(wx.EVT_BUTTON, self.onClickDelete)
+        
+        self.close_button.Bind(wx.EVT_BUTTON, self.onClickClose)
 
         # Layout
         ## Group the buttons
         self.button_sizer = wx.BoxSizer(wx.VERTICAL)
-        self.button_sizer.Add(self.new_button, 1,
-            wx.FIXED_MINSIZE | wx.ALIGN_CENTER)
-        self.button_sizer.Add(self.edit_button, 1,
-            wx.FIXED_MINSIZE | wx.ALIGN_CENTER)
-        self.button_sizer.Add(self.delete_button, 1,
-            wx.FIXED_MINSIZE | wx.ALIGN_CENTER)
+        self.button_sizer.Add(self.new_button, 0,
+            wx.FIXED_MINSIZE | wx.EXPAND | wx.LEFT | wx.BOTTOM, getSpace('minor'))
+        self.button_sizer.Add(self.edit_button, 0,
+            wx.FIXED_MINSIZE | wx.EXPAND | wx.LEFT | wx.BOTTOM, getSpace('minor'))
+        self.button_sizer.Add(self.delete_button, 0,
+            wx.FIXED_MINSIZE | wx.EXPAND | wx.LEFT, getSpace('minor'))
 
         ## Group the buttons with the spool list
-        self.list_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        self.list_sizer = wx.StaticBoxSizer(wx.HORIZONTAL, self, label = "Spool List")
         self.list_sizer.Add(self.spool_list, 1, wx.EXPAND)
-        self.list_sizer.Add(self.button_sizer, 0, wx.ALIGN_CENTER)
+        self.list_sizer.Add(self.button_sizer, 0, wx.ALIGN_TOP)
 
         ## Layout the whole thing
-        self.full_sizer = wx.BoxSizer(wx.VERTICAL)
-        self.full_sizer.Add(self.current_spools_dialog, 0, wx.EXPAND)
-        self.full_sizer.Add(self.list_sizer, 1, wx.ALL | wx.EXPAND, 10)
+        self.topsizer = wx.BoxSizer(wx.VERTICAL)
+        self.topsizer.Add(self.current_spools_dialog, 0, wx.EXPAND)
+        self.topsizer.Add(self.list_sizer, 1, wx.ALL | wx.EXPAND, getSpace('minor'))
+        self.topsizer.Add(self.close_button, 0, 
+                          wx.FIXED_MINSIZE | wx.ALIGN_RIGHT | wx.BOTTOM | wx.RIGHT, getSpace('minor'))
 
-        self.SetSizerAndFit(self.full_sizer)
+        self.SetSizerAndFit(self.topsizer)
+        self.CentreOnParent()
 
     def onClickAdd(self, event):
         """Open the window for customizing the new spool."""
@@ -92,7 +100,7 @@ class SpoolManagerMainWindow(wx.Frame):
         spool_index = self.spool_list.GetFirstSelected()
         if spool_index == -1 :
             self.statusbar.SetStatusText(
-                "Could not load the spool. No spool selected.")
+                _("Could not load the spool. No spool selected."))
             return 0
         else:
             spool_name = self.spool_list.GetItemText(spool_index)
@@ -102,7 +110,7 @@ class SpoolManagerMainWindow(wx.Frame):
         spool_extruder = self.spool_manager.isLoaded(spool_name)
         if spool_extruder > -1:
             self.statusbar.SetStatusText(
-                "Spool '%s' is already loaded for Extruder %d." % 
+                _("Spool '%s' is already loaded for Extruder %d.") % 
                 (spool_name, spool_extruder))
             return 0
 
@@ -110,7 +118,7 @@ class SpoolManagerMainWindow(wx.Frame):
         self.spool_manager.load(spool_name, extruder)
         self.current_spools_dialog.refreshDialog(self.spool_manager)
         self.statusbar.SetStatusText(
-            "Loaded spool '%s' for Extruder %d." % (spool_name, extruder))
+            _("Loaded spool '%s' for Extruder %d.") % (spool_name, extruder))
 
     def onClickUnload(self, event, extruder):
         """Unload the spool from the correspondent extruder."""
@@ -120,10 +128,10 @@ class SpoolManagerMainWindow(wx.Frame):
             self.spool_manager.unload(extruder)
             self.current_spools_dialog.refreshDialog(self.spool_manager)
             self.statusbar.SetStatusText(
-                "Unloaded spool from Extruder %d." % extruder)
+                _("Unloaded spool from Extruder %d.") % extruder)
         else:
             self.statusbar.SetStatusText(
-                "There is no spool loaded for Extruder %d." % extruder)
+                _("There is no spool loaded for Extruder %d.") % extruder)
 
     def onClickEdit(self, event):
         """Open the window for editing the data of the selected spool."""
@@ -132,7 +140,7 @@ class SpoolManagerMainWindow(wx.Frame):
         spool_index = self.spool_list.GetFirstSelected()
         if spool_index == -1 :
             self.statusbar.SetStatusText(
-                "Could not edit the spool. No spool selected.")
+                _("Could not edit the spool. No spool selected."))
             return 0
 
         # Open the edit window
@@ -148,7 +156,7 @@ class SpoolManagerMainWindow(wx.Frame):
         spool_index = self.spool_list.GetFirstSelected()
         if spool_index == -1 :
             self.statusbar.SetStatusText(
-                "Could not delete the spool. No spool selected.")
+                _("Could not delete the spool. No spool selected."))
             return 0
         else:
             spool_name = self.spool_list.GetItemText(spool_index)
@@ -156,9 +164,9 @@ class SpoolManagerMainWindow(wx.Frame):
 
         # Ask confirmation for deleting
         delete_dialog = wx.MessageDialog(self,
-            message = "Are you sure you want to delete the '%s' spool" %
+            message = _("Are you sure you want to delete the '%s' spool") %
                 spool_name,
-            caption = "Delete Spool",
+            caption = _("Delete Spool"),
             style = wx.YES_NO | wx.ICON_EXCLAMATION)
 
         if delete_dialog.ShowModal() == wx.ID_YES:
@@ -167,8 +175,10 @@ class SpoolManagerMainWindow(wx.Frame):
             self.spool_list.refreshList(self.spool_manager)
             self.current_spools_dialog.refreshDialog(self.spool_manager)
             self.statusbar.SetStatusText(
-                "Deleted spool '%s'." % spool_name)
-
+                _("Deleted spool '%s'.") % spool_name)
+    
+    def onClickClose(self, event):
+        self.Destroy()
 
 class SpoolListView(wx.ListView):
     """
@@ -178,8 +188,8 @@ class SpoolListView(wx.ListView):
     def __init__(self, parent, spool_manager):
         wx.ListView.__init__(self, parent,
             style = wx.LC_REPORT | wx.LC_SINGLE_SEL)
-        self.InsertColumn(0, "Spool", width = wx.LIST_AUTOSIZE_USEHEADER)
-        self.InsertColumn(1, "Filament", width = wx.LIST_AUTOSIZE_USEHEADER)
+        self.InsertColumn(0, _("Spool"), width = wx.LIST_AUTOSIZE_USEHEADER)
+        self.InsertColumn(1, _("Filament"), width = wx.LIST_AUTOSIZE_USEHEADER)
         self.populateList(spool_manager)
 
         # "Program" the layout
@@ -216,11 +226,11 @@ class CurrentSpoolDialog(wx.Panel):
         self.parent = parent
         self.extruders = spool_manager.getExtruderCount()
 
-        full_sizer = wx.BoxSizer(wx.VERTICAL)
+        topsizer = wx.BoxSizer(wx.VERTICAL)
 
         # Calculate the minimum size needed to properly display the
         # extruder information
-        min_size = self.GetTextExtent("    Remaining filament: 0000000.00")
+        min_size = self.GetTextExtent(_("Default Very Long Spool Name"))
 
         # Generate a dialog for every extruder
         self.extruder_dialog = []
@@ -230,17 +240,19 @@ class CurrentSpoolDialog(wx.Panel):
         dialog_sizer = []
         for i in range(self.extruders):
             # Generate the dialog with the spool information
+            textlabel = wx.StaticText(self, label = _("Name:\nRemaining filament:"),
+                          style = wx.ALIGN_RIGHT)
             self.extruder_dialog.append(
                 wx.StaticText(self, style = wx.ST_ELLIPSIZE_END))
             self.extruder_dialog[i].SetMinSize(wx.Size(min_size.width, -1))
 
             # Generate the "load" and "unload" buttons
-            load_button.append(wx.Button(self, label = "Load"))
+            load_button.append(wx.Button(self, label = _("Load")))
             load_button[i].SetToolTip(
-                "Load selected spool for Extruder %d" % i)
-            unload_button.append(wx.Button(self, label = "Unload"))
+                _("Load selected spool for Extruder %d") % i)
+            unload_button.append(wx.Button(self, label = _("Unload")))
             unload_button[i].SetToolTip(
-                "Unload the spool for Extruder %d" % i)
+                _("Unload the spool for Extruder %d") % i)
 
             # "Program" the buttons
             load_button[i].Bind(wx.EVT_BUTTON,
@@ -251,21 +263,22 @@ class CurrentSpoolDialog(wx.Panel):
             # Layout
             button_sizer.append(wx.BoxSizer(wx.VERTICAL))
             button_sizer[i].Add(load_button[i], 0,
-                wx.FIXED_MINSIZE | wx.ALIGN_CENTER)
+                wx.FIXED_MINSIZE | wx.ALIGN_CENTER | wx.BOTTOM, getSpace('minor'))
             button_sizer[i].Add(unload_button[i], 0,
                 wx.FIXED_MINSIZE | wx.ALIGN_CENTER)
 
-            dialog_sizer.append(wx.BoxSizer(wx.HORIZONTAL))
-            dialog_sizer[i].Add(self.extruder_dialog[i], 1, wx.ALIGN_CENTER)
-            dialog_sizer[i].AddSpacer(10)
+            dialog_sizer.append(wx.StaticBoxSizer(wx.HORIZONTAL, self, label = _("Spool for Extruder %d:") % i))
+            dialog_sizer[i].Add(textlabel, 0, wx.ALIGN_TOP)
+            dialog_sizer[i].AddSpacer(getSpace('major'))
+            dialog_sizer[i].Add(self.extruder_dialog[i], 1, wx.ALIGN_TOP)
+            dialog_sizer[i].AddSpacer(getSpace('major'))
             dialog_sizer[i].Add(button_sizer[i], 0, wx.EXPAND)
 
-            full_sizer.Add(dialog_sizer[i], 0, wx.ALL | wx.EXPAND, 10)
+            topsizer.Add(dialog_sizer[i], 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, getSpace('major'))
 
         self.refreshDialog(spool_manager)
 
-        self.SetSizerAndFit(full_sizer)
-
+        self.SetSizerAndFit(topsizer)
 
     def refreshDialog(self, spool_manager):
         """Retrieve the current spools from the Spool Manager."""
@@ -273,9 +286,8 @@ class CurrentSpoolDialog(wx.Panel):
         for i in range(self.extruders):
             spool_name = spool_manager.getSpoolName(i)
             spool_filament = spool_manager.getRemainingFilament(i)
-            label = ("Spool for Extruder %d:\n" % i +
-                     "    Name:               %s\n" % spool_name +
-                     "    Remaining filament: %.2f" % spool_filament)
+            label = ("%s\n" % spool_name +
+                     "%.2f mm" % spool_filament)
             self.extruder_dialog[i].SetLabelText(label)
 
 
@@ -284,10 +296,10 @@ def checkOverwrite(parent, spool_name):
     """Ask the user whether or not to overwrite the existing spool."""
 
     overwrite_dialog = wx.MessageDialog(parent,
-        message = "A spool with the name '%s'' already exists." %
+        message = _("A spool with the name '%s'' already exists.") %
             spool_name +
-            "Do you wish to overwrite it?",
-        caption = "Overwrite",
+            _("Do you wish to overwrite it?"),
+        caption = _("Overwrite"),
         style = wx.YES_NO | wx.ICON_EXCLAMATION)
 
     if overwrite_dialog.ShowModal() == wx.ID_YES:
@@ -300,45 +312,60 @@ def getFloat(parent, number):
     Check whether the input number is a float. Either return the number or
     return False.
     """
+    if ',' in number:
+        parent.parent.statusbar.SetStatusText(_("Value contains a comma, please use a point for decimal values: %s") % number)
+        return False
+
     try:
         return float(number)
     except ValueError:
-        parent.statusbar.SetStatusText("Unrecognized number: %s" % number)
+        parent.parent.statusbar.SetStatusText(_("Unrecognized number: %s") % number)
         return False
 
-
 # ---------------------------------------------------------------------------
-class SpoolManagerAddWindow(wx.Frame):
+class SpoolManagerAddWindow(wx.Dialog):
     """Window for adding spools."""
 
     def __init__(self, parent):
 
-        wx.Frame.__init__(self, parent,
-            title = "Add Spool",
-            style = wx.DEFAULT_FRAME_STYLE | wx.FRAME_FLOAT_ON_PARENT)
-
-        self.statusbar = self.CreateStatusBar()
+        wx.Dialog.__init__(self, parent,
+            title = _("Add Spool"),
+            style = wx.DEFAULT_DIALOG_STYLE)
 
         self.parent = parent
 
         self.SetIcon(parent.GetIcon())
 
         # Generate the dialogs
-        self.name_dialog = LabeledTextCtrl(self,
-            "Name", "Default Spool", "")
-        self.diameter_dialog = LabeledTextCtrl(self,
-            "Diameter", "1.75", "mm")
-        self.diameter_dialog.SetToolTip(
-            "Typically, either 1.75 mm or 2.85 mm (a.k.a '3')")
-        self.weight_dialog = LabeledTextCtrl(self,
-            "Weight", "1", "Kg")
-        self.density_dialog = LabeledTextCtrl(self,
-            "Density", "1.25", "g/cm^3")
-        self.density_dialog.SetToolTip(
-            "Typical densities are 1.25 g/cm^3 for PLA and 1.08 g/cm^3 for" +
-            " ABS")
-        self.length_dialog = LabeledTextCtrl(self,
-            "Length", "332601.35", "mm")
+        # The wx.TextCtrl variabels need to be declared before the loop, empty
+        self.name_dialog = wx.TextCtrl(self, -1)
+        self.diameter_dialog = wx.TextCtrl(self, -1)
+        self.weight_dialog = wx.TextCtrl(self, -1)
+        self.density_dialog = wx.TextCtrl(self, -1)
+        self.length_dialog = wx.TextCtrl(self, -1)
+
+        # The list contains field-description, textctrl variabel, default value, unit, tooltip;
+        name_dlg = [_("Name:"), self.name_dialog, _("Default Spool"), "", ""]
+        diameter_dlg = [_("Diameter:"), self.diameter_dialog, "1.75", "mm", _("Typically, either 1.75 mm or 2.85 mm")]
+        weight_dlg = [_("Weight:"), self.weight_dialog, "1.0", "kg", ""]
+        density_dlg = [_("Density:"), self.density_dialog, "1.25", "g/cm^3", _("Typical densities are 1.25 g/cm^3 for PLA,\n1.27 g/cm^3 for PETG or 1.08 g/cm^3 for ABS")]
+        length_dlg = [_("Length"), self.length_dialog, "332601.35", "mm", ""]
+        dialog_list = [name_dlg, diameter_dlg, weight_dlg, density_dlg, length_dlg]
+
+        minwidth = self.GetTextExtent('Default Long Spool Name').width
+        grid = wx.FlexGridSizer(rows = 0, cols = 3, hgap = getSpace('minor'), vgap = getSpace('minor'))
+
+        for dialog in dialog_list:
+            grid.Add(wx.StaticText(self, -1, dialog[0], size = (-1, -1), style = wx.TE_RIGHT), 0, wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL)
+            dialog[1].ChangeValue(dialog[2])
+            dialog[1].SetMinSize((minwidth, -1))
+            if dialog[4] != "":
+                dialog[1].SetToolTip(dialog[4])
+            grid.Add(dialog[1])
+            if dialog[3] == "":
+                grid.Add((0,0))
+            else:
+                grid.Add(wx.StaticText(self, -1, dialog[3], size = (-1, -1)), wx.ALIGN_CENTER_VERTICAL)
 
         # "Program" the dialogs
         self.diameter_dialog.Bind(wx.EVT_TEXT, self.calculateLength)
@@ -352,48 +379,44 @@ class SpoolManagerAddWindow(wx.Frame):
 
         # "Program" the bottom buttons
         self.add_button.Bind(wx.EVT_BUTTON, self.onClickAdd)
+        self.add_button.SetDefault()
         self.cancel_button.Bind(wx.EVT_BUTTON, self.onClickCancel)
 
         # Layout
-        ## Group the bottom buttons
-        self.bottom_buttons_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        self.bottom_buttons_sizer.Add(self.add_button, 0, wx.FIXED_MINSIZE)
-        self.bottom_buttons_sizer.Add(self.cancel_button, 0, wx.FIXED_MINSIZE)
+        ## Setup the bottom buttons
+        self.bottom_buttons_sizer = wx.StdDialogButtonSizer()
+        self.bottom_buttons_sizer.SetAffirmativeButton(self.add_button)
+        self.bottom_buttons_sizer.AddButton(self.cancel_button)
+
+        self.bottom_buttons_sizer.Realize()
 
         ## Group the whole window
-        self.full_sizer = wx.BoxSizer(wx.VERTICAL)
-        self.full_sizer.Add(self.name_dialog, 0,
-            wx.TOP | wx.BOTTOM | wx.EXPAND,  10)
-        self.full_sizer.Add(self.diameter_dialog, 0, wx.EXPAND)
-        self.full_sizer.Add(self.weight_dialog, 0, wx.EXPAND)
-        self.full_sizer.Add(self.density_dialog, 0, wx.EXPAND)
-        self.full_sizer.Add(self.length_dialog, 0, wx.EXPAND)
-        self.full_sizer.Add(self.bottom_buttons_sizer, 0,
-            wx.ALL | wx.ALIGN_CENTER_HORIZONTAL, 10)
+        self.topsizer = wx.BoxSizer(wx.VERTICAL)
+        self.topsizer.Add(grid, 1, wx.EXPAND | wx.ALL, getSpace('major'))
+        self.topsizer.Add(wx.StaticLine(self, -1, style = wx.LI_HORIZONTAL), 0, wx.EXPAND)
+        self.topsizer.Add(self.bottom_buttons_sizer, 0, wx.ALIGN_RIGHT | wx.ALL, getSpace('stddlg'))
 
-        self.SetSizerAndFit(self.full_sizer)
+        self.SetSizerAndFit(self.topsizer)
+        self.CentreOnParent()
+        self.name_dialog.SetFocus()
 
-        # Don't allow this window to be resized in height
-        add_window_size = self.GetSize()
-        self.SetMaxSize((-1, add_window_size.height))
-
-    def onClickAdd(self, event):
+    def onClickAdd(self, ev):
         """Add the new spool and close the window."""
 
-        spool_name = self.name_dialog.field.GetValue()
-        spool_length = getFloat(self, self.length_dialog.field.GetValue())
+        spool_name = self.name_dialog.GetValue()
+        spool_length = getFloat(self, self.length_dialog.GetValue())
 
         # Check whether the length is actually a number
         if not spool_length:
-            self.statusbar.SetStatusText(
-                "ERROR: Unrecognized length: %s." %
-                    self.length_dialog.field.GetValue())
+            self.parent.statusbar.SetStatusText(
+                _("ERROR: Unrecognized length: %s.") %
+                    self.length_dialog.GetValue())
             return -1
 
         # The remaining filament should always be a positive number
         if not spool_length > 0:
-            self.statusbar.SetStatusText(
-                "ERROR: Length is zero or negative: %.2f." % spool_length)
+            self.parent.statusbar.SetStatusText(
+                _("ERROR: Length is zero or negative: %.2f.") % spool_length)
             return -1
 
         # Check whether the name is already used. If it is used, prompt the
@@ -411,32 +434,33 @@ class SpoolManagerAddWindow(wx.Frame):
         self.parent.current_spools_dialog.refreshDialog(
                 self.parent.spool_manager)
         self.parent.statusbar.SetStatusText(
-            "Added new spool '%s'" % spool_name +
-            " with %.2f mm of remaining filament." % spool_length)
+            _("Added new spool '%s'") % spool_name +
+            _(" with %.2f mm of remaining filament.") % spool_length)
 
-        self.Close(True)
+        self.Destroy()
 
     def onClickCancel(self, event):
         """Do nothing and close the window."""
-        self.Close(True)
-        self.parent.statusbar.SetStatusText("")
+        self.Destroy()
 
     def calculateLength(self, event):
         """
         Calculate the length of the filament given the mass, diameter and
         density of the filament. Set the 'Length' field to this quantity.
         """
-
-        mass = getFloat(self, self.weight_dialog.field.GetValue())
-        diameter = getFloat(self, self.diameter_dialog.field.GetValue())
-        density = getFloat(self, self.density_dialog.field.GetValue())
+        print(self.weight_dialog.GetValue())
+        print(self.diameter_dialog.GetValue())
+        print(self.density_dialog.GetValue())
+        mass = getFloat(self, self.weight_dialog.GetValue())
+        diameter = getFloat(self, self.diameter_dialog.GetValue())
+        density = getFloat(self, self.density_dialog.GetValue())
         if mass and diameter and density:
             pi = 3.14159265359
             length = 4e6 * mass / pi / diameter**2 / density
-            self.length_dialog.field.ChangeValue("%.2f" % length)
-            self.statusbar.SetStatusText("")
+            self.parent.statusbar.SetStatusText("")
+            self.length_dialog.ChangeValue("%.2f" % length)
         else:
-            self.length_dialog.field.ChangeValue("---")
+            self.length_dialog.ChangeValue("---")
 
     def calculateWeight(self, event):
         """
@@ -444,52 +468,26 @@ class SpoolManagerAddWindow(wx.Frame):
         density of the filament. Set the 'Weight' field to this value.
         """
 
-        length = getFloat(self, self.length_dialog.field.GetValue())
-        diameter = getFloat(self, self.diameter_dialog.field.GetValue())
-        density = getFloat(self, self.density_dialog.field.GetValue())
+        length = getFloat(self, self.length_dialog.GetValue())
+        diameter = getFloat(self, self.diameter_dialog.GetValue())
+        density = getFloat(self, self.density_dialog.GetValue())
         if length and diameter and density:
             pi = 3.14159265359
             mass = length * pi * diameter**2 * density / 4e6
-            self.weight_dialog.field.ChangeValue("%.2f" % mass)
-            self.statusbar.SetStatusText("")
+            self.parent.statusbar.SetStatusText("")
+            self.weight_dialog.ChangeValue("%.2f" % mass)
         else:
-            self.weight_dialog.field.ChangeValue("---")
-
-
-class LabeledTextCtrl(wx.Panel):
-    """
-    Group together a wxTextCtrl with a preceding and a subsequent wxStaticText.
-    """
-
-    def __init__(self, parent, preceding_text, field_value, subsequent_text):
-        wx.Panel.__init__(self, parent)
-        self.pretext = wx.StaticText(self, label = preceding_text,
-            style = wx.ALIGN_RIGHT)
-        self.field = wx.TextCtrl(self, value = field_value)
-        self.subtext = wx.StaticText(self, label = subsequent_text)
-
-        # Layout the panel
-        self.sizer = wx.BoxSizer(wx.HORIZONTAL)
-        self.sizer.Add(self.pretext, 0, wx.LEFT | wx.ALIGN_CENTER_VERTICAL, 10)
-        self.sizer.SetItemMinSize(self.pretext, (80, -1))
-        self.sizer.Add(self.field, 1, wx.EXPAND)
-        self.sizer.Add(self.subtext, 0, wx.RIGHT | wx.ALIGN_CENTER_VERTICAL, 10)
-        self.sizer.SetItemMinSize(self.subtext, (50, -1))
-
-        self.SetSizerAndFit(self.sizer)
-
+            self.weight_dialog.ChangeValue("---")
 
 # ---------------------------------------------------------------------------
-class SpoolManagerEditWindow(wx.Frame):
+class SpoolManagerEditWindow(wx.Dialog):
     """Window for editing the name or the length of a spool."""
 
     def __init__(self, parent, spool_name, spool_length):
 
-        wx.Frame.__init__(self, parent,
-            title = "Edit Spool",
-            style = wx.DEFAULT_FRAME_STYLE | wx.FRAME_FLOAT_ON_PARENT)
-
-        self.statusbar = self.CreateStatusBar()
+        wx.Dialog.__init__(self, parent,
+            title = _("Edit Spool"),
+            style = wx.DEFAULT_DIALOG_STYLE)
 
         self.parent = parent
 
@@ -501,25 +499,33 @@ class SpoolManagerEditWindow(wx.Frame):
         # Set how many millimeters will the buttons add or subtract
         self.quantities = [-100.0, -50.0, -10.0, 10.0, 50.0, 100.0]
 
+        # All widgets go into a sizer which is assigned to this panel
+        self.panel = wx.Panel(self)
+
         # Generate the name field
-        self.name_field = LabeledTextCtrl(self,
-            "Name", self.old_spool_name, "")
+        self.name_title = wx.StaticText(self.panel, -1, _("Name:"))
+        minwidth = self.GetTextExtent('Default Very Long Spool Name').width
+        self.name_field = wx.TextCtrl(self.panel, -1, self.old_spool_name, style = wx.TE_RIGHT)
+        self.name_field.SetMinSize((minwidth, -1))
 
         # Generate the length field and buttons
-        self.length_title = wx.StaticText(self, label = "Remaining filament:")
-        self.minus3_button = wx.Button(self,
+        self.length_title = wx.StaticText(self.panel, label = _("Remaining filament:"), style = wx.ALIGN_RIGHT)
+        self.length_field = wx.TextCtrl(self.panel, -1,
+            value = str(self.old_spool_length), style = wx.TE_RIGHT)
+        self.length_field.SetMinSize((minwidth, -1))
+        
+        self.minus3_button = wx.Button(self.panel,
             label = str(self.quantities[0]), style = wx.BU_EXACTFIT)
-        self.minus2_button = wx.Button(self,
+        self.minus2_button = wx.Button(self.panel,
             label = str(self.quantities[1]), style = wx.BU_EXACTFIT)
-        self.minus1_button = wx.Button(self,
+        self.minus1_button = wx.Button(self.panel,
             label = str(self.quantities[2]), style = wx.BU_EXACTFIT)
-        self.length_field = wx.TextCtrl(self,
-            value = str(self.old_spool_length))
-        self.plus1_button = wx.Button(self,
+
+        self.plus1_button = wx.Button(self.panel,
             label = "+" + str(self.quantities[3]), style = wx.BU_EXACTFIT)
-        self.plus2_button = wx.Button(self,
+        self.plus2_button = wx.Button(self.panel,
             label = "+" + str(self.quantities[4]), style = wx.BU_EXACTFIT)
-        self.plus3_button = wx.Button(self,
+        self.plus3_button = wx.Button(self.panel,
             label = "+" + str(self.quantities[5]), style = wx.BU_EXACTFIT)
 
         # "Program" the length buttons
@@ -530,8 +536,9 @@ class SpoolManagerEditWindow(wx.Frame):
         self.plus2_button.Bind(wx.EVT_BUTTON, self.changeLength)
         self.plus3_button.Bind(wx.EVT_BUTTON, self.changeLength)
 
-        # Generate the bottom buttons
+        # Generate the bottom buttons        
         self.save_button = wx.Button(self, wx.ID_SAVE)
+        self.save_button.SetDefault()
         self.cancel_button = wx.Button(self, wx.ID_CANCEL)
 
         # "Program" the bottom buttons
@@ -539,66 +546,82 @@ class SpoolManagerEditWindow(wx.Frame):
         self.cancel_button.Bind(wx.EVT_BUTTON, self.onClickCancel)
 
         # Layout
-        ## Group the length field and its correspondent buttons
-        self.length_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        self.length_sizer.Add(self.minus3_button, 0,
-                              wx.FIXED_MINSIZE | wx.ALIGN_CENTER)
-        self.length_sizer.Add(self.minus2_button, 0,
-                              wx.FIXED_MINSIZE | wx.ALIGN_CENTER)
-        self.length_sizer.Add(self.minus1_button, 0,
-                              wx.FIXED_MINSIZE | wx.ALIGN_CENTER)
-        self.length_sizer.Add(self.length_field, 1, wx.EXPAND)
-        self.length_sizer.Add(self.plus1_button, 0,
-                              wx.FIXED_MINSIZE | wx.ALIGN_CENTER)
-        self.length_sizer.Add(self.plus2_button, 0,
-                              wx.FIXED_MINSIZE | wx.ALIGN_CENTER)
-        self.length_sizer.Add(self.plus3_button, 0,
-                              wx.FIXED_MINSIZE | wx.ALIGN_CENTER)
+        ## Group the length field and its correspondent buttons             
+        self.btn_sizer = wx.StaticBoxSizer(wx.HORIZONTAL, self.panel)
+        self.btn_sizer.Add(self.minus3_button, 0,
+                              wx.FIXED_MINSIZE | wx.ALIGN_CENTER | wx.RIGHT, getSpace('mini'))
+        self.btn_sizer.Add(self.minus2_button, 0,
+                              wx.FIXED_MINSIZE | wx.ALIGN_CENTER | wx.RIGHT, getSpace('mini'))
+        self.btn_sizer.Add(self.minus1_button, 0,
+                              wx.FIXED_MINSIZE | wx.ALIGN_CENTER | wx.RIGHT, getSpace('mini'))
+        self.btn_sizer.AddSpacer(getSpace('major'))
+        self.btn_sizer.Add(self.plus1_button, 0,
+                              wx.FIXED_MINSIZE | wx.ALIGN_CENTER | wx.LEFT, getSpace('mini'))
+        self.btn_sizer.Add(self.plus2_button, 0,
+                              wx.FIXED_MINSIZE | wx.ALIGN_CENTER | wx.LEFT, getSpace('mini'))
+        self.btn_sizer.Add(self.plus3_button, 0,
+                              wx.FIXED_MINSIZE | wx.ALIGN_CENTER | wx.LEFT, getSpace('mini'))
 
         ## Group the bottom buttons
-        self.bottom_buttons_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        self.bottom_buttons_sizer.Add(self.save_button, 0, wx.EXPAND)
-        self.bottom_buttons_sizer.Add(self.cancel_button, 0, wx.EXPAND)
+        self.bottom_buttons_sizer = wx.StdDialogButtonSizer()
+
+        self.bottom_buttons_sizer.AddButton(self.save_button)
+        self.bottom_buttons_sizer.AddButton(self.cancel_button)
+        self.save_button.SetDefault()
+
+        self.bottom_buttons_sizer.Realize()
 
         ## Lay out the whole window
-        self.full_sizer = wx.BoxSizer(wx.VERTICAL)
-        self.full_sizer.Add(self.name_field, 0, wx.EXPAND)
-        self.full_sizer.AddSpacer(10)
-        self.full_sizer.Add(self.length_title, 0,
-            wx.LEFT | wx.RIGHT | wx.EXPAND, 10)
-        self.full_sizer.Add(self.length_sizer, 0,
-            wx.LEFT | wx.RIGHT | wx.EXPAND, 10)
-        self.full_sizer.AddSpacer(10)
-        self.full_sizer.Add(self.bottom_buttons_sizer, 0, wx.ALIGN_CENTER)
+        grid = wx.GridBagSizer(hgap = getSpace('minor'), vgap = getSpace('minor'))
+        
+        grid.Add((getSpace('mini'),getSpace('mini')), pos = (0, 0), span = (1, 4),
+                                    border = 0, flag = 0) #pos = row, col, span = rowspan, colspan
+        grid.Add(self.name_title, pos = (1, 1), span = (1, 1),
+                                    border = 0, flag = wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL | wx.EXPAND)
+        grid.Add(self.name_field, pos = (1, 2), span = (1, 1),
+                                    border = 0, flag = wx.ALIGN_LEFT)
+        grid.Add(self.length_title, pos = (2, 1), span = (1, 1),
+                                    border = 0, flag = wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL | wx.EXPAND)
+        grid.Add(self.length_field, pos = (2, 2), span = (1, 1),
+                                    border = 0, flag = wx.ALIGN_LEFT)
+        grid.Add(self.btn_sizer, pos = (3, 1), span = (1, 2),
+                                    border = 0, flag = wx.ALIGN_CENTER | wx.EXPAND)
+        grid.Add((getSpace('mini'),getSpace('mini')), pos = (3, 3), span = (1, 1),
+                                    border = 0, flag = 0)
 
-        self.SetSizerAndFit(self.full_sizer)
+        self.panel.SetSizer(grid)
+        topsizer = wx.BoxSizer(wx.VERTICAL)
+        topsizer.Add(self.panel, wx.EXPAND)
+        topsizer.Add(wx.StaticLine(self, -1, style = wx.LI_HORIZONTAL), 0, wx.EXPAND | wx.TOP, getSpace('mini'))
+        topsizer.Add(self.bottom_buttons_sizer, 0, wx.ALIGN_RIGHT | wx.ALL, getSpace('stddlg'))
 
-        # Don't allow this window to be resized in height
-        edit_window_size = self.GetSize()
-        self.SetMaxSize((-1, edit_window_size.height))
+        self.SetSizer(topsizer)
+        self.Fit()
+        self.CentreOnParent()
+        self.name_field.SetFocus()
 
     def changeLength(self, event):
         new_length = getFloat(self, self.length_field.GetValue())
         if new_length:
             new_length = new_length + float(event.GetEventObject().GetLabel())
             self.length_field.ChangeValue("%.2f" % new_length)
-            self.statusbar.SetStatusText("")
+            #self.statusbar.SetStatusText("")
 
     def onClickSave(self, event):
 
-        new_spool_name = self.name_field.field.GetValue()
+        new_spool_name = self.name_field.GetValue()
         new_spool_length = getFloat(self, self.length_field.GetValue())
 
         # Check whether the length is actually a number
         if not new_spool_length:
             self.statusbar.SetStatusText(
-                "ERROR: Unrecognized length: %s." %
+                _("ERROR: Unrecognized length: %s.") %
                     self.length_field.GetValue())
             return -1
 
         if not new_spool_length > 0:
             self.statusbar.SetStatusText(
-                "ERROR: Length is zero or negative: %.2f." % new_spool_length)
+                _("ERROR: Length is zero or negative: %.2f.") % new_spool_length)
             return -1
 
         # Check whether the "old" spool was loaded
@@ -629,11 +652,11 @@ class SpoolManagerEditWindow(wx.Frame):
         self.parent.current_spools_dialog.refreshDialog(
             self.parent.spool_manager)
         self.parent.statusbar.SetStatusText(
-            "Edited spool '%s'" % new_spool_name +
-            " with %.2f mm of remaining filament." % new_spool_length)
+            _("Edited spool '%s'") % new_spool_name +
+            _(" with %.2f mm of remaining filament.") % new_spool_length)
 
-        self.Close(True)
+        self.Destroy()
 
     def onClickCancel(self, event):
-            self.Close(True)
+            self.Destroy()
             self.parent.statusbar.SetStatusText("")

--- a/printrun/spoolmanager/spoolmanager_gui.py
+++ b/printrun/spoolmanager/spoolmanager_gui.py
@@ -109,7 +109,7 @@ class SpoolManagerMainWindow(wx.Frame):
 
     def onClickAdd(self, event):
         """Open the window for customizing the new spool."""
-        SpoolManagerAddWindow(self).Show(True)
+        SpoolManagerAddWindow(self).ShowModal()
 
     def onClickLoad(self, event, extruder):
         """Load the selected spool to the correspondent extruder."""
@@ -168,7 +168,7 @@ class SpoolManagerMainWindow(wx.Frame):
         # Open the edit window
         spool_name = self.spool_list.GetItemText(spool_index)
         spool_length = self.spool_list.GetItemText(spool_index, 1)
-        SpoolManagerEditWindow(self, spool_name, spool_length).Show(True)
+        SpoolManagerEditWindow(self, spool_name, spool_length).ShowModal()
         self.statusbar.SetLabel("")
 
     def onClickDelete(self, event):

--- a/printrun/spoolmanager/spoolmanager_gui.py
+++ b/printrun/spoolmanager/spoolmanager_gui.py
@@ -17,6 +17,9 @@
 
 import wx
 from printrun.gui.widgets import get_space
+from printrun.utils import install_locale
+install_locale('pronterface')
+# Set up Internationalization using gettext
 
 class SpoolManagerMainWindow(wx.Frame):
     """

--- a/printrun/spoolmanager/spoolmanager_gui.py
+++ b/printrun/spoolmanager/spoolmanager_gui.py
@@ -428,6 +428,7 @@ class SpoolManagerAddWindow(wx.Dialog):
         # "Program" the bottom buttons
         self.add_button.Bind(wx.EVT_BUTTON, self.onClickAdd)
         self.add_button.SetDefault()
+        self.SetAffirmativeId(wx.ID_ADD)
         self.cancel_button.Bind(wx.EVT_BUTTON, self.onClickCancel)
 
         # Layout
@@ -488,11 +489,13 @@ class SpoolManagerAddWindow(wx.Dialog):
             _(" with %.2f mm of remaining filament.") % spool_length)
         self.parent.Layout() # Layout() is needed to ellipsize possible overlength status
 
+        self.EndModal(True)
         self.Destroy()
 
     def onClickCancel(self, event):
         """Do nothing and close the window."""
         self.parent.statusbar.SetLabel("")
+        self.EndModal(True)
         self.Destroy()
 
     def calculateLength(self, event):
@@ -594,12 +597,13 @@ class SpoolManagerEditWindow(wx.Dialog):
 
         # Generate the bottom buttons        
         self.save_button = wx.Button(self, wx.ID_SAVE)
-        self.save_button.SetDefault()
         self.cancel_button = wx.Button(self, wx.ID_CANCEL)
 
         # "Program" the bottom buttons
         self.save_button.Bind(wx.EVT_BUTTON, self.onClickSave)
         self.cancel_button.Bind(wx.EVT_BUTTON, self.onClickCancel)
+        self.save_button.SetDefault()
+        self.SetAffirmativeId(wx.ID_SAVE)
 
         # Layout
         ## Group the length field and its correspondent buttons             
@@ -622,7 +626,6 @@ class SpoolManagerEditWindow(wx.Dialog):
         self.bottom_buttons_sizer = wx.StdDialogButtonSizer()
         self.bottom_buttons_sizer.AddButton(self.save_button)
         self.bottom_buttons_sizer.AddButton(self.cancel_button)
-        self.save_button.SetDefault()
         self.bottom_buttons_sizer.Realize()
 
         ## Lay out the whole window
@@ -707,9 +710,10 @@ class SpoolManagerEditWindow(wx.Dialog):
             _("Edited spool '%s'") % new_spool_name +
             _(" with %.2f mm of remaining filament.") % new_spool_length)
         self.parent.Layout() # Layout() is needed to ellipsize possible overlength status
-
+        self.EndModal(True)
         self.Destroy()
 
     def onClickCancel(self, event):
             self.parent.statusbar.SetLabel("")
+            self.EndModal(True)
             self.Destroy()

--- a/printrun/spoolmanager/spoolmanager_gui.py
+++ b/printrun/spoolmanager/spoolmanager_gui.py
@@ -16,8 +16,7 @@
 # Copyright 2017 Rock Storm <rockstorm@gmx.com>
 
 import wx
-from . import spoolmanager
-from printrun.gui.widgets import getSpace
+from printrun.gui.widgets import get_space
 
 class SpoolManagerMainWindow(wx.Frame):
     """
@@ -29,8 +28,8 @@ class SpoolManagerMainWindow(wx.Frame):
 
     def __init__(self, parent, spool_manager):
         wx.Frame.__init__(self, parent,
-            title = _("Spool Manager"),
-            style = wx.DEFAULT_FRAME_STYLE)
+                          title = _("Spool Manager"),
+                          style = wx.DEFAULT_FRAME_STYLE)
 
         # An empty wx.Frame has a darker background on win, but filled with a panel it looks native
         self.panel = wx.Panel(self, -1)
@@ -43,7 +42,12 @@ class SpoolManagerMainWindow(wx.Frame):
 
         # Generate the dialogs showing the current spools
         self.current_spools_dialog = CurrentSpoolDialog(self.panel,
-            self.spool_manager)
+                                                        self.spool_manager)
+
+        # Check if any spools are loaded on non-exisiting extruders
+        for spool in self.spool_manager.getSpoolList():
+            if self.spool_manager.isLoaded(spool[0]) > (spool_manager.getExtruderCount() - 1):
+                spool_manager.unload(self.spool_manager.isLoaded(spool[0]))
 
         # Generate the list of recorded spools
         self.spool_list = SpoolListView(self.panel, self.spool_manager)
@@ -57,13 +61,13 @@ class SpoolManagerMainWindow(wx.Frame):
         self.panel.delete_button = wx.Button(self.panel, wx.ID_DELETE)
         self.panel.delete_button.SetToolTip(_("Delete the selected spool"))
         self.panel.delete_button.Disable()
-        
+
         # Instead of a real statusbar, a virtual statusbar is combined with the close button
         self.statusbar = wx.StaticText(self.panel, -1, "", style = wx.ST_ELLIPSIZE_END)
         statusfont = wx.Font(self.statusbar.GetFont())
         statusfont.MakeSmaller()
         self.statusbar.SetFont(statusfont)
-        
+
         self.close_button = wx.Button(self.panel, wx.ID_CLOSE)
         self.bottom_button_sizer = wx.BoxSizer(wx.HORIZONTAL)
         self.bottom_button_sizer.Add(self.statusbar, 1, wx.ALIGN_CENTER_VERTICAL)
@@ -73,33 +77,36 @@ class SpoolManagerMainWindow(wx.Frame):
         self.panel.new_button.Bind(wx.EVT_BUTTON, self.onClickAdd)
         self.panel.edit_button.Bind(wx.EVT_BUTTON, self.onClickEdit)
         self.panel.delete_button.Bind(wx.EVT_BUTTON, self.onClickDelete)
-        
+
         self.close_button.Bind(wx.EVT_BUTTON, self.onClickClose)
 
         # Layout
         ## Group the buttons
         self.list_button_sizer = wx.BoxSizer(wx.VERTICAL)
         self.list_button_sizer.Add(self.panel.new_button, 0,
-            wx.FIXED_MINSIZE | wx.EXPAND | wx.LEFT | wx.BOTTOM, getSpace('minor'))
+            wx.FIXED_MINSIZE | wx.EXPAND | wx.LEFT | wx.BOTTOM, get_space('minor'))
         self.list_button_sizer.Add(self.panel.edit_button, 0,
-            wx.FIXED_MINSIZE | wx.EXPAND | wx.LEFT | wx.BOTTOM, getSpace('minor'))
+            wx.FIXED_MINSIZE | wx.EXPAND | wx.LEFT | wx.BOTTOM, get_space('minor'))
         self.list_button_sizer.Add(self.panel.delete_button, 0,
-            wx.FIXED_MINSIZE | wx.EXPAND | wx.LEFT, getSpace('minor'))
+            wx.FIXED_MINSIZE | wx.EXPAND | wx.LEFT, get_space('minor'))
 
         ## Group the buttons with the spool list
         self.list_sizer = wx.StaticBoxSizer(wx.HORIZONTAL, self.panel, label = _("Spool List"))
-        self.list_sizer.Add(self.spool_list, 1, wx.EXPAND | wx.LEFT | wx.TOP | wx.BOTTOM, getSpace('staticbox'))
-        self.list_sizer.Add(self.list_button_sizer, 0, wx.ALIGN_TOP | wx.TOP | wx.RIGHT, getSpace('staticbox'))
+        self.list_sizer.Add(self.spool_list, 1,
+                            wx.EXPAND | wx.LEFT | wx.TOP | wx.BOTTOM, get_space('staticbox'))
+        self.list_sizer.Add(self.list_button_sizer, 0,
+                            wx.ALIGN_TOP | wx.TOP | wx.RIGHT, get_space('staticbox'))
 
         ## Layout the whole thing
         widgetsizer = wx.BoxSizer(wx.VERTICAL)
-        widgetsizer.Add(self.list_sizer, 1, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, getSpace('minor'))
-        widgetsizer.Add(self.current_spools_dialog, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, getSpace('minor'))
+        widgetsizer.Add(self.list_sizer, 1, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, get_space('minor'))
+        widgetsizer.Add(self.current_spools_dialog, 0,
+                        wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, get_space('minor'))
         widgetsizer.Add(wx.StaticLine(self.panel, -1, style = wx.LI_HORIZONTAL), 0, wx.EXPAND)
-        widgetsizer.Add(self.bottom_button_sizer, 0, wx.EXPAND | wx.ALL, getSpace('stddlg-frame'))
+        widgetsizer.Add(self.bottom_button_sizer, 0, wx.EXPAND | wx.ALL, get_space('stddlg-frame'))
 
         ## Make sure the frame has the right size when it opens, but can still be resized
-        self.panel.SetSizer(widgetsizer)      
+        self.panel.SetSizer(widgetsizer)
         topsizer = wx.BoxSizer(wx.VERTICAL)
         topsizer.Add(self.panel, -1, wx.EXPAND)
         self.SetSizer(topsizer)
@@ -116,22 +123,21 @@ class SpoolManagerMainWindow(wx.Frame):
 
         # Check whether there is a spool selected
         spool_index = self.spool_list.GetFirstSelected()
-        if spool_index == -1 :
+        if spool_index == -1:
             self.statusbar.SetLabel(
                 _("Could not load the spool. No spool selected."))
-            return 0
-        else:
-            spool_name = self.spool_list.GetItemText(spool_index)
-            self.statusbar.SetLabel("")
+            return
+        spool_name = self.spool_list.GetItemText(spool_index)
+        self.statusbar.SetLabel("")
 
         # If selected spool is already loaded, do nothing
         spool_extruder = self.spool_manager.isLoaded(spool_name)
         if spool_extruder > -1:
             self.statusbar.SetLabel(
-                _("Spool '%s' is already loaded for Extruder %d.") % 
+                _("Spool '%s' is already loaded for Extruder %d.") %
                 (spool_name, spool_extruder))
-            self.Layout() # Layout() is needed to ellipsize possible overlength status
-            return 0
+            self.Layout()  # Layout() is needed to ellipsize possible overlength status
+            return
 
         # Load the selected spool and refresh the current spools dialog
         self.spool_manager.load(spool_name, extruder)
@@ -139,13 +145,13 @@ class SpoolManagerMainWindow(wx.Frame):
         self.current_spools_dialog.unload_button[extruder].Enable()
         self.statusbar.SetLabel(
             _("Loaded spool '%s' for Extruder %d.") % (spool_name, extruder))
-        self.Layout() # Layout() is needed to ellipsize possible overlength status
+        self.Layout()  # Layout() is needed to ellipsize possible overlength status
 
     def onClickUnload(self, event, extruder):
         """Unload the spool from the correspondent extruder."""
 
         spool_name = self.spool_manager.getSpoolName(extruder)
-        if spool_name != None:
+        if spool_name is not None:
             self.spool_manager.unload(extruder)
             self.current_spools_dialog.refreshDialog(self.spool_manager)
             self.statusbar.SetLabel(
@@ -160,10 +166,10 @@ class SpoolManagerMainWindow(wx.Frame):
 
         # Check whether there is a spool selected
         spool_index = self.spool_list.GetFirstSelected()
-        if spool_index == -1 :
+        if spool_index == -1:
             self.statusbar.SetLabel(
                 _("Could not edit the spool. No spool selected."))
-            return 0
+            return
 
         # Open the edit window
         spool_name = self.spool_list.GetItemText(spool_index)
@@ -176,20 +182,18 @@ class SpoolManagerMainWindow(wx.Frame):
 
         # Get the selected spool
         spool_index = self.spool_list.GetFirstSelected()
-        if spool_index == -1 :
+        if spool_index == -1:
             self.statusbar.SetLabel(
                 _("Could not delete the spool. No spool selected."))
-            return 0
-        else:
-            spool_name = self.spool_list.GetItemText(spool_index)
-            self.statusbar.SetLabel("")
+            return
+        spool_name = self.spool_list.GetItemText(spool_index)
+        self.statusbar.SetLabel("")
 
         # Ask confirmation for deleting
         delete_dialog = wx.MessageDialog(self,
-            message = _("Are you sure you want to delete the '%s' spool?") %
-                spool_name,
-            caption = _("Delete Spool"),
-            style = wx.YES_NO | wx.ICON_EXCLAMATION)
+                                         message = _("Are you sure you want to delete the '%s' spool?") %
+                                         spool_name, caption = _("Delete Spool"),
+                                         style = wx.YES_NO | wx.ICON_EXCLAMATION)
 
         if delete_dialog.ShowModal() == wx.ID_YES:
             # Remove spool
@@ -198,7 +202,7 @@ class SpoolManagerMainWindow(wx.Frame):
             self.current_spools_dialog.refreshDialog(self.spool_manager)
             self.statusbar.SetLabel(
                 _("Deleted spool '%s'.") % spool_name)
-    
+
     def onClickClose(self, event):
         self.Destroy()
 
@@ -209,7 +213,7 @@ class SpoolListView(wx.ListView):
 
     def __init__(self, parent, spool_manager):
         wx.ListView.__init__(self, parent,
-            style = wx.LC_REPORT | wx.LC_SINGLE_SEL)
+                             style = wx.LC_REPORT | wx.LC_SINGLE_SEL)
         self.InsertColumn(0, _("Spool"), width = wx.LIST_AUTOSIZE_USEHEADER)
         self.InsertColumn(1, _("Filament"), width = wx.LIST_AUTOSIZE_USEHEADER)
         self.populateList(spool_manager)
@@ -224,9 +228,9 @@ class SpoolListView(wx.ListView):
     def populateList(self, spool_manager):
         """Get the list of recorded spools from the Spool Manager."""
         spool_list = spool_manager.getSpoolList()
-        for i in range(len(spool_list)):
-            spool_list[i][1] = str(spool_list[i][1]) + " mm"
-            self.Append(spool_list[i])
+        for spool in spool_list:
+            spool[1] = str(spool[1]) + " mm"
+            self.Append(spool)
 
     def refreshList(self, spool_manager):
         """Refresh the list by re-reading the Spool Manager list."""
@@ -267,7 +271,7 @@ class CurrentSpoolDialog(wx.Panel):
 
         # Calculate the minimum size needed to properly display the
         # extruder information
-        min_size = self.GetTextExtent(_("Default Very Long Spool Name"))
+        min_size = self.GetTextExtent("Default Very Long Spool Name")
 
         # Generate a dialog for every extruder
         self.extruder_dialog = []
@@ -278,7 +282,7 @@ class CurrentSpoolDialog(wx.Panel):
         for i in range(self.extruders):
             # Generate the dialog with the spool information
             textlabel = wx.StaticText(self, label = _("Name:\nRemaining filament:"),
-                          style = wx.ALIGN_RIGHT)
+                                      style = wx.ALIGN_RIGHT)
             self.extruder_dialog.append(
                 wx.StaticText(self, style = wx.ST_ELLIPSIZE_END))
             self.extruder_dialog[i].SetMinSize(wx.Size(min_size.width, -1))
@@ -301,18 +305,19 @@ class CurrentSpoolDialog(wx.Panel):
             # Layout
             button_sizer.append(wx.BoxSizer(wx.HORIZONTAL))
             button_sizer[i].Add(load_button[i], 0,
-                wx.FIXED_MINSIZE | wx.ALIGN_CENTER | wx.RIGHT, getSpace('minor'))
+                wx.FIXED_MINSIZE | wx.ALIGN_CENTER | wx.RIGHT, get_space('minor'))
             button_sizer[i].Add(self.unload_button[i], 0,
                 wx.FIXED_MINSIZE | wx.ALIGN_CENTER)
 
-            dialog_sizer.append(wx.StaticBoxSizer(wx.HORIZONTAL, self, label = _("Spool for Extruder %d:") % i))
-            dialog_sizer[i].Add(textlabel, 0, wx.ALIGN_TOP | wx.ALL, getSpace('staticbox'))
-            dialog_sizer[i].AddSpacer(getSpace('minor'))
-            dialog_sizer[i].Add(self.extruder_dialog[i], 1, wx.ALIGN_TOP | wx.TOP, getSpace('staticbox'))
-            dialog_sizer[i].AddSpacer(getSpace('major'))
-            dialog_sizer[i].Add(button_sizer[i], 0, wx.EXPAND | wx.RIGHT, getSpace('staticbox'))
+            dialog_sizer.append(wx.StaticBoxSizer(wx.HORIZONTAL,
+                                                  self, label = _("Spool for Extruder %d:") % i))
+            dialog_sizer[i].Add(textlabel, 0, wx.ALIGN_TOP | wx.ALL, get_space('staticbox'))
+            dialog_sizer[i].AddSpacer(get_space('minor'))
+            dialog_sizer[i].Add(self.extruder_dialog[i], 1, wx.ALIGN_TOP | wx.TOP, get_space('staticbox'))
+            dialog_sizer[i].AddSpacer(get_space('major'))
+            dialog_sizer[i].Add(button_sizer[i], 0, wx.EXPAND | wx.RIGHT, get_space('staticbox'))
 
-            csd_sizer.Add(dialog_sizer[i], 0, wx.EXPAND | wx.TOP, getSpace('minor'))
+            csd_sizer.Add(dialog_sizer[i], 0, wx.EXPAND | wx.TOP, get_space('minor'))
 
         self.refreshDialog(spool_manager)
 
@@ -323,7 +328,7 @@ class CurrentSpoolDialog(wx.Panel):
 
         for i in range(self.extruders):
             spool_name = spool_manager.getSpoolName(i)
-            if spool_name != None:
+            if spool_name is not None:
                 self.unload_button[i].Enable()
             else:
                 self.unload_button[i].Disable()
@@ -341,13 +346,11 @@ def checkOverwrite(parent, spool_name):
         message = _("A spool with the name '%s'' already exists.") %
             spool_name +
             _("Do you wish to overwrite it?"),
-        caption = _("Overwrite"),
-        style = wx.YES_NO | wx.ICON_EXCLAMATION)
+            caption = _("Overwrite"),
+            style = wx.YES_NO | wx.ICON_EXCLAMATION)
 
-    if overwrite_dialog.ShowModal() == wx.ID_YES:
-        return True
-    else:
-        return False
+    return overwrite_dialog.ShowModal() == wx.ID_YES
+
 
 def getFloat(parent, number):
     """
@@ -356,14 +359,14 @@ def getFloat(parent, number):
     """
     if ',' in number:
         parent.parent.statusbar.SetLabel(_("Value contains a comma, please use a point for decimal values: %s") % number)
-        parent.parent.Layout() # Layout() is needed to ellipsize possible overlength status
+        parent.parent.Layout()  # Layout() is needed to ellipsize possible overlength status
         return False
 
     try:
         return float(number)
     except ValueError:
         parent.parent.statusbar.SetLabel(_("Unrecognized number: %s") % number)
-        parent.parent.Layout() # Layout() is needed to ellipsize possible overlength status
+        parent.parent.Layout()  # Layout() is needed to ellipsize possible overlength status
         return False
 
 # ---------------------------------------------------------------------------
@@ -373,8 +376,8 @@ class SpoolManagerAddWindow(wx.Dialog):
     def __init__(self, parent):
 
         wx.Dialog.__init__(self, parent,
-            title = _("Add Spool"),
-            style = wx.DEFAULT_DIALOG_STYLE)
+                           title = _("Add Spool"),
+                           style = wx.DEFAULT_DIALOG_STYLE)
 
         self.parent = parent
 
@@ -390,18 +393,21 @@ class SpoolManagerAddWindow(wx.Dialog):
 
         # The list contains field-description, textctrl value, default value, unit, tooltip;
         name_dlg = [_("Name:"), self.name_dialog, _("Default Spool"), "", ""]
-        diameter_dlg = [_("Diameter:"), self.diameter_dialog, "1.75", "mm", _("Typically, either 1.75 mm or 2.85 mm")]
+        diameter_dlg = [_("Diameter:"), self.diameter_dialog, "1.75", "mm",
+                        _("Typically, either 1.75 mm or 2.85 mm")]
         weight_dlg = [_("Weight:"), self.weight_dialog, "1.0", "kg", ""]
-        density_dlg = [_("Density:"), self.density_dialog, "1.25", "g/cm^3", _("Typical densities are 1.25 g/cm^3 for PLA,\n1.27 g/cm^3 for PETG or 1.08 g/cm^3 for ABS")]
+        density_dlg = [_("Density:"), self.density_dialog, "1.25", "g/cm^3",
+                       _("Typical densities are 1.25 g/cm^3 for PLA,\n1.27 g/cm^3 for PETG or 1.08 g/cm^3 for ABS")]
         length_dlg = [_("Length:"), self.length_dialog, "332601.35", "mm", ""]
         dialog_list = [name_dlg, diameter_dlg, weight_dlg, density_dlg, length_dlg]
 
         minwidth = self.GetTextExtent('Default Long Spool Name').width
-        grid = wx.FlexGridSizer(rows = 0, cols = 3, hgap = getSpace('minor'), vgap = getSpace('minor'))
+        grid = wx.FlexGridSizer(rows = 0, cols = 3, hgap = get_space('minor'), vgap = get_space('minor'))
 
         for dialog in dialog_list:
             # Add a field-description label
-            grid.Add(wx.StaticText(self, -1, dialog[0], size = (-1, -1)), 0, wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL)
+            grid.Add(wx.StaticText(self, -1, dialog[0], size = (-1, -1)), 0,
+                     wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL)
             # Give the TextCtrl the right value
             dialog[1].ChangeValue(dialog[2])
             dialog[1].SetMinSize((minwidth, -1))
@@ -411,7 +417,7 @@ class SpoolManagerAddWindow(wx.Dialog):
             grid.Add(dialog[1])
             # Add a label for the unit
             if dialog[3] == "":
-                grid.Add((0,0))
+                grid.Add((0, 0))
             else:
                 grid.Add(wx.StaticText(self, -1, dialog[3], size = (-1, -1)), 0, wx.ALIGN_CENTER_VERTICAL)
 
@@ -441,9 +447,11 @@ class SpoolManagerAddWindow(wx.Dialog):
 
         ## Group the whole window
         self.topsizer = wx.BoxSizer(wx.VERTICAL)
-        self.topsizer.Add(grid, 1, wx.EXPAND | wx.TOP | wx.LEFT | wx.RIGHT, getSpace('major'))
-        self.topsizer.Add(wx.StaticLine(self, -1, style = wx.LI_HORIZONTAL), 0, wx.EXPAND | wx.TOP, getSpace('minor'))
-        self.topsizer.Add(self.bottom_buttons_sizer, 0, wx.ALIGN_RIGHT | wx.ALL, getSpace('stddlg'))
+        self.topsizer.Add(grid, 1, wx.EXPAND | wx.TOP | wx.LEFT | wx.RIGHT, get_space('major'))
+        self.topsizer.Add(wx.StaticLine(self, -1, style = wx.LI_HORIZONTAL), 0,
+                          wx.EXPAND | wx.TOP, get_space('minor'))
+        self.topsizer.Add(self.bottom_buttons_sizer, 0,
+                          wx.ALIGN_RIGHT | wx.ALL, get_space('stddlg'))
 
         self.SetSizerAndFit(self.topsizer)
         self.CentreOnParent()
@@ -457,18 +465,17 @@ class SpoolManagerAddWindow(wx.Dialog):
 
         # Check whether the length is actually a number
         if not spool_length:
-            self.parent.statusbar.SetLabel(
-                _("ERROR: Unrecognized length: %s.") %
-                    self.length_dialog.GetValue())
-            self.parent.Layout() # Layout() is needed to ellipsize possible overlength status
-            return -1
+            self.parent.statusbar.SetLabel(_("ERROR: Unrecognized length: %s.") %
+                                           self.length_dialog.GetValue())
+            self.parent.Layout()  # Layout() is needed to ellipsize possible overlength status
+            return
 
         # The remaining filament should always be a positive number
         if not spool_length > 0:
-            self.parent.statusbar.SetLabel(
-                _("ERROR: Length is zero or negative: %.2f.") % spool_length)
-            self.parent.Layout() # Layout() is needed to ellipsize possible overlength status
-            return -1
+            self.parent.statusbar.SetLabel(_("ERROR: Length is zero or negative: %.2f.") %
+                                           spool_length)
+            self.parent.Layout()  # Layout() is needed to ellipsize possible overlength status
+            return
 
         # Check whether the name is already used. If it is used, prompt the
         # user before overwriting it
@@ -477,7 +484,7 @@ class SpoolManagerAddWindow(wx.Dialog):
                 # Remove the "will be overwritten" spool
                 self.parent.spool_manager.remove(spool_name)
             else:
-                return 0
+                return
 
         # Add the new spool
         self.parent.spool_manager.add(spool_name, spool_length)
@@ -487,7 +494,7 @@ class SpoolManagerAddWindow(wx.Dialog):
         self.parent.statusbar.SetLabel(
             _("Added new spool '%s'") % spool_name +
             _(" with %.2f mm of remaining filament.") % spool_length)
-        self.parent.Layout() # Layout() is needed to ellipsize possible overlength status
+        self.parent.Layout()  # Layout() is needed to ellipsize possible overlength status
 
         self.EndModal(True)
         self.Destroy()
@@ -559,11 +566,12 @@ class SpoolManagerEditWindow(wx.Dialog):
         self.name_field.SetMinSize((minwidth, -1))
 
         # Generate the length field
-        self.length_title = wx.StaticText(self, label = _("Remaining filament:"), style = wx.ALIGN_RIGHT)
-        self.length_field = wx.TextCtrl(self, -1,
-            value = str(self.old_spool_length), style = wx.TE_RIGHT)
+        self.length_title = wx.StaticText(self, label = _("Remaining filament:"),
+                                          style = wx.ALIGN_RIGHT)
+        self.length_field = wx.TextCtrl(self, -1, value = str(self.old_spool_length),
+                                        style = wx.TE_RIGHT)
         self.length_field.SetMinSize((minwidth, -1))
-        
+
         # Generate the buttons
         button_min_width = self.GetTextExtent('  +000.0  ').width
         self.minus3_button = wx.Button(self,
@@ -579,7 +587,7 @@ class SpoolManagerEditWindow(wx.Dialog):
             label = "+" + str(self.quantities[4]))
         self.plus3_button = wx.Button(self,
             label = "+" + str(self.quantities[5]))
-        
+
         self.minus3_button.SetSize((button_min_width, -1))
         self.minus2_button.SetSize((button_min_width, -1))
         self.minus1_button.SetSize((button_min_width, -1))
@@ -595,7 +603,7 @@ class SpoolManagerEditWindow(wx.Dialog):
         self.plus2_button.Bind(wx.EVT_BUTTON, self.changeLength)
         self.plus3_button.Bind(wx.EVT_BUTTON, self.changeLength)
 
-        # Generate the bottom buttons        
+        # Generate the bottom buttons
         self.save_button = wx.Button(self, wx.ID_SAVE)
         self.cancel_button = wx.Button(self, wx.ID_CANCEL)
 
@@ -606,21 +614,22 @@ class SpoolManagerEditWindow(wx.Dialog):
         self.SetAffirmativeId(wx.ID_SAVE)
 
         # Layout
-        ## Group the length field and its correspondent buttons             
+        ## Group the length field and its correspondent buttons
         self.btn_sizer = wx.StaticBoxSizer(wx.HORIZONTAL, self)
         self.btn_sizer.Add(self.minus3_button, 0,
-                              wx.FIXED_MINSIZE | wx.ALIGN_CENTER | wx.LEFT | wx.TOP | wx.BOTTOM, getSpace('staticbox'))
+                           wx.FIXED_MINSIZE | wx.ALIGN_CENTER | wx.LEFT | wx.TOP | wx.BOTTOM,
+                           get_space('staticbox'))
         self.btn_sizer.Add(self.minus2_button, 0,
-                              wx.FIXED_MINSIZE | wx.ALIGN_CENTER | wx.LEFT | wx.RIGHT, getSpace('mini'))
+                           wx.FIXED_MINSIZE | wx.ALIGN_CENTER | wx.LEFT | wx.RIGHT, get_space('mini'))
         self.btn_sizer.Add(self.minus1_button, 0,
-                              wx.FIXED_MINSIZE | wx.ALIGN_CENTER | wx.RIGHT, getSpace('mini'))
-        self.btn_sizer.AddSpacer(getSpace('major'))
+                           wx.FIXED_MINSIZE | wx.ALIGN_CENTER | wx.RIGHT, get_space('mini'))
+        self.btn_sizer.AddSpacer(get_space('major'))
         self.btn_sizer.Add(self.plus1_button, 0,
-                              wx.FIXED_MINSIZE | wx.ALIGN_CENTER | wx.LEFT, getSpace('mini'))
+                           wx.FIXED_MINSIZE | wx.ALIGN_CENTER | wx.LEFT, get_space('mini'))
         self.btn_sizer.Add(self.plus2_button, 0,
-                              wx.FIXED_MINSIZE | wx.ALIGN_CENTER | wx.LEFT | wx.RIGHT, getSpace('mini'))
+                           wx.FIXED_MINSIZE | wx.ALIGN_CENTER | wx.LEFT | wx.RIGHT, get_space('mini'))
         self.btn_sizer.Add(self.plus3_button, 0,
-                              wx.FIXED_MINSIZE | wx.ALIGN_CENTER | wx.RIGHT, getSpace('staticbox'))
+                           wx.FIXED_MINSIZE | wx.ALIGN_CENTER | wx.RIGHT, get_space('staticbox'))
 
         ## Group the bottom buttons
         self.bottom_buttons_sizer = wx.StdDialogButtonSizer()
@@ -629,24 +638,25 @@ class SpoolManagerEditWindow(wx.Dialog):
         self.bottom_buttons_sizer.Realize()
 
         ## Lay out the whole window
-        grid = wx.GridBagSizer(hgap = getSpace('minor'), vgap = getSpace('minor'))
-        
+        grid = wx.GridBagSizer(hgap = get_space('minor'), vgap = get_space('minor'))
+
         # Gridbagsizer: pos = (row, col), span = (rowspan, colspan)
-        grid.Add(self.name_title, pos = (0, 0), span = (1, 1),
-                                    border = 0, flag = wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL | wx.EXPAND)
-        grid.Add(self.name_field, pos = (0, 1), span = (1, 1),
-                                    border = 0, flag = wx.ALIGN_LEFT)
-        grid.Add(self.length_title, pos = (1, 0), span = (1, 1),
-                                    border = 0, flag = wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL | wx.EXPAND)
-        grid.Add(self.length_field, pos = (1, 1), span = (1, 1),
-                                    border = 0, flag = wx.ALIGN_LEFT)
-        grid.Add(self.btn_sizer, pos = (2, 0), span = (1, 2),
-                                    border = 0, flag = wx.ALIGN_CENTER | wx.EXPAND)
-        
+        grid.Add(self.name_title, pos = (0, 0), span = (1, 1), border = 0,
+                 flag = wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL | wx.EXPAND)
+        grid.Add(self.name_field, pos = (0, 1), span = (1, 1), border = 0,
+                 flag = wx.ALIGN_LEFT)
+        grid.Add(self.length_title, pos = (1, 0), span = (1, 1), border = 0,
+                 flag = wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL | wx.EXPAND)
+        grid.Add(self.length_field, pos = (1, 1), span = (1, 1), border = 0,
+                 flag = wx.ALIGN_LEFT)
+        grid.Add(self.btn_sizer, pos = (2, 0), span = (1, 2), border = 0,
+                 flag = wx.ALIGN_CENTER | wx.EXPAND)
+
         topsizer = wx.BoxSizer(wx.VERTICAL)
-        topsizer.Add(grid, 1, wx.EXPAND | wx.TOP | wx.LEFT | wx.RIGHT, getSpace('major'))
-        topsizer.Add(wx.StaticLine(self, -1, style = wx.LI_HORIZONTAL), 0, wx.EXPAND | wx.TOP, getSpace('minor'))
-        topsizer.Add(self.bottom_buttons_sizer, 0, wx.ALIGN_RIGHT | wx.ALL, getSpace('stddlg'))
+        topsizer.Add(grid, 1, wx.EXPAND | wx.TOP | wx.LEFT | wx.RIGHT, get_space('major'))
+        topsizer.Add(wx.StaticLine(self, -1, style = wx.LI_HORIZONTAL), 0,
+                     wx.EXPAND | wx.TOP, get_space('minor'))
+        topsizer.Add(self.bottom_buttons_sizer, 0, wx.ALIGN_RIGHT | wx.ALL, get_space('stddlg'))
 
         self.SetSizer(topsizer)
         self.Fit()
@@ -669,15 +679,15 @@ class SpoolManagerEditWindow(wx.Dialog):
         if not new_spool_length:
             self.parent.statusbar.SetLabel(
                 _("ERROR: Unrecognized length: %s.") %
-                    self.length_field.GetValue())
-            self.parent.Layout() # Layout() is needed to ellipsize possible overlength status
-            return -1
+                self.length_field.GetValue())
+            self.parent.Layout()  # Layout() is needed to ellipsize possible overlength status
+            return
 
         if not new_spool_length > 0:
             self.parent.statusbar.SetLabel(
                 _("ERROR: Length is zero or negative: %.2f.") % new_spool_length)
-            self.parent.Layout() # Layout() is needed to ellipsize possible overlength status
-            return -1
+            self.parent.Layout()  # Layout() is needed to ellipsize possible overlength status
+            return
 
         # Check whether the "old" spool was loaded
         new_spool_extruder = self.parent.spool_manager.isLoaded(
@@ -695,7 +705,7 @@ class SpoolManagerEditWindow(wx.Dialog):
                     self.parent.spool_manager.remove(self.old_spool_name)
                     self.parent.spool_manager.remove(new_spool_name)
                 else:
-                    return 0
+                    return
             else:
                 # Remove only the "old" spool
                 self.parent.spool_manager.remove(self.old_spool_name)
@@ -709,11 +719,11 @@ class SpoolManagerEditWindow(wx.Dialog):
         self.parent.statusbar.SetLabel(
             _("Edited spool '%s'") % new_spool_name +
             _(" with %.2f mm of remaining filament.") % new_spool_length)
-        self.parent.Layout() # Layout() is needed to ellipsize possible overlength status
+        self.parent.Layout()  # Layout() is needed to ellipsize possible overlength status
         self.EndModal(True)
         self.Destroy()
 
     def onClickCancel(self, event):
-            self.parent.statusbar.SetLabel("")
-            self.EndModal(True)
-            self.Destroy()
+        self.parent.statusbar.SetLabel("")
+        self.EndModal(True)
+        self.Destroy()

--- a/printrun/spoolmanager/spoolmanager_gui.py
+++ b/printrun/spoolmanager/spoolmanager_gui.py
@@ -32,7 +32,7 @@ class SpoolManagerMainWindow(wx.Frame):
             title = _("Spool Manager"),
             style = wx.DEFAULT_FRAME_STYLE)
 
-        # wx.Frame looks better with a panel in it
+        # An empty wx.Frame has a darker background on win, but filled with a panel it looks native
         self.panel = wx.Panel(self, -1)
 
         self.SetIcon(parent.GetIcon())
@@ -88,8 +88,8 @@ class SpoolManagerMainWindow(wx.Frame):
 
         ## Group the buttons with the spool list
         self.list_sizer = wx.StaticBoxSizer(wx.HORIZONTAL, self.panel, label = _("Spool List"))
-        self.list_sizer.Add(self.spool_list, 1, wx.EXPAND | wx.ALL, getSpace('staticbox'))
-        self.list_sizer.Add(self.list_button_sizer, 0, wx.ALIGN_TOP | wx.ALL, getSpace('staticbox'))
+        self.list_sizer.Add(self.spool_list, 1, wx.EXPAND | wx.LEFT | wx.TOP | wx.BOTTOM, getSpace('staticbox'))
+        self.list_sizer.Add(self.list_button_sizer, 0, wx.ALIGN_TOP | wx.TOP | wx.RIGHT, getSpace('staticbox'))
 
         ## Layout the whole thing
         widgetsizer = wx.BoxSizer(wx.VERTICAL)
@@ -98,7 +98,7 @@ class SpoolManagerMainWindow(wx.Frame):
         widgetsizer.Add(wx.StaticLine(self.panel, -1, style = wx.LI_HORIZONTAL), 0, wx.EXPAND)
         widgetsizer.Add(self.bottom_button_sizer, 0, wx.EXPAND | wx.ALL, getSpace('stddlg-frame'))
 
-        ## Make sure the frame has the right size when it open, but is still resizeable
+        ## Make sure the frame has the right size when it opens, but can still be resized
         self.panel.SetSizer(widgetsizer)      
         topsizer = wx.BoxSizer(wx.VERTICAL)
         topsizer.Add(self.panel, -1, wx.EXPAND)
@@ -186,7 +186,7 @@ class SpoolManagerMainWindow(wx.Frame):
 
         # Ask confirmation for deleting
         delete_dialog = wx.MessageDialog(self,
-            message = _("Are you sure you want to delete the '%s' spool") %
+            message = _("Are you sure you want to delete the '%s' spool?") %
                 spool_name,
             caption = _("Delete Spool"),
             style = wx.YES_NO | wx.ICON_EXCLAMATION)
@@ -248,7 +248,6 @@ class SpoolListView(wx.ListView):
     def onItemDeselect(self, event):
         self.Parent.edit_button.Disable()
         self.Parent.delete_button.Disable()
-
 
 class CurrentSpoolDialog(wx.Panel):
     """
@@ -493,6 +492,7 @@ class SpoolManagerAddWindow(wx.Dialog):
 
     def onClickCancel(self, event):
         """Do nothing and close the window."""
+        self.parent.statusbar.SetLabel("")
         self.Destroy()
 
     def calculateLength(self, event):
@@ -711,5 +711,5 @@ class SpoolManagerEditWindow(wx.Dialog):
         self.Destroy()
 
     def onClickCancel(self, event):
-            self.Destroy()
             self.parent.statusbar.SetLabel("")
+            self.Destroy()

--- a/printrun/stlplater.py
+++ b/printrun/stlplater.py
@@ -234,53 +234,56 @@ class StlPlaterPanel(PlaterPanel):
                                           circular = circular_platform,
                                           antialias_samples = antialias_samples)
             
-            # Insert Cutting tool
-            cutpanel = wx.Panel(self.menupanel)
-            cutsizer = wx.StaticBoxSizer(wx.VERTICAL, cutpanel, label = _("Cutting Tool"))
-            ## Prepare buttons for all cut axis
-            axis_sizer = self.axis_sizer = wx.BoxSizer(wx.HORIZONTAL)
-            cutxplusbutton = wx.ToggleButton(cutpanel, label = _("+X"), style = wx.BU_EXACTFIT)
-            cutxplusbutton.Bind(wx.EVT_TOGGLEBUTTON, lambda event: self.start_cutting_tool(event, "x", 1))
-            axis_sizer.Add(cutxplusbutton, 1, wx.EXPAND | wx.RIGHT, getSpace('mini'))
-            cutyplusbutton = wx.ToggleButton(cutpanel, label = _("+Y"), style = wx.BU_EXACTFIT)
-            cutyplusbutton.Bind(wx.EVT_TOGGLEBUTTON, lambda event: self.start_cutting_tool(event, "y", 1))
-            axis_sizer.Add(cutyplusbutton, 1, wx.EXPAND | wx.RIGHT, getSpace('mini'))
-            cutzplusbutton = wx.ToggleButton(cutpanel, label = _("+Z"), style = wx.BU_EXACTFIT)
-            cutzplusbutton.Bind(wx.EVT_TOGGLEBUTTON, lambda event: self.start_cutting_tool(event, "z", 1))
-            axis_sizer.Add(cutzplusbutton, 1, wx.EXPAND | wx.RIGHT, getSpace('mini'))
-            cutxminusbutton = wx.ToggleButton(cutpanel, label = _("-X"), style = wx.BU_EXACTFIT)
-            cutxminusbutton.Bind(wx.EVT_TOGGLEBUTTON, lambda event: self.start_cutting_tool(event, "x", -1))
-            axis_sizer.Add(cutxminusbutton, 1, wx.EXPAND | wx.RIGHT, getSpace('mini'))
-            cutyminusbutton = wx.ToggleButton(cutpanel, label = _("-Y"), style = wx.BU_EXACTFIT)
-            cutyminusbutton.Bind(wx.EVT_TOGGLEBUTTON, lambda event: self.start_cutting_tool(event, "y", -1))
-            axis_sizer.Add(cutyminusbutton, 1, wx.EXPAND | wx.RIGHT, getSpace('mini'))
-            cutzminusbutton = wx.ToggleButton(cutpanel, label = _("-Z"), style = wx.BU_EXACTFIT)
-            cutzminusbutton.Bind(wx.EVT_TOGGLEBUTTON, lambda event: self.start_cutting_tool(event, "z", -1))
-            axis_sizer.Add(cutzminusbutton, 1, flag = wx.EXPAND)
-
-            cutsizer.Add(wx.StaticText(cutpanel, -1, _("Choose axis to cut along:")), 0, wx.BOTTOM, getSpace('minor'))
-            cutsizer.Add(axis_sizer, 0, wx.EXPAND, wx.BOTTOM, getSpace('minor'))
-            cutsizer.Add(wx.StaticText(cutpanel, -1, _("Doubleclick to set the cutting plane.")), 0, wx.TOP | wx.BOTTOM, getSpace('minor'))
-            # Process cut button
-            cut_processbutton = wx.Button(cutpanel, label = _("Process Cut"))
-            cut_processbutton.Bind(wx.EVT_BUTTON, self.cut_confirm)
-            cut_processbutton.Disable()
-            self.cut_processbutton = cut_processbutton
-            cutsizer.Add(cut_processbutton, 0, flag = wx.EXPAND)
-
-            cutpanel.SetSizer(cutsizer)
-            nrows = self.menusizer.GetRows()
-            self.menusizer.Add(cutpanel, pos = (nrows, 0), span = (1, 1), 
-                               flag = wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, border = getSpace('mini'))
+            # Insert cutting tool panel
+            self.insert_cutting_tool()
 
         else:
             viewer = showstl(self, (580, 580), (0, 0))
         self.simarrange_path = simarrange_path
         self.set_viewer(viewer)
-        self.Layout()
+        #self.Layout()
         self.SetMinClientSize((self.menupanel.GetEffectiveMinSize().width, 
                                self.menupanel.GetEffectiveMinSize().height + 48))
 
+    def insert_cutting_tool(self):
+        # Insert Cutting tool
+        cutsizer = wx.StaticBoxSizer(wx.VERTICAL, self.menupanel, label = _("Cutting Tool"))
+        ## Prepare buttons for all cut axis
+        axis_sizer = self.axis_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        cutxplusbutton = wx.ToggleButton(self.menupanel, label = _("+X"), style = wx.BU_EXACTFIT)
+        cutxplusbutton.Bind(wx.EVT_TOGGLEBUTTON, lambda event: self.start_cutting_tool(event, "x", 1))
+        axis_sizer.Add(cutxplusbutton, 1, wx.EXPAND | wx.RIGHT, getSpace('mini'))
+        cutyplusbutton = wx.ToggleButton(self.menupanel, label = _("+Y"), style = wx.BU_EXACTFIT)
+        cutyplusbutton.Bind(wx.EVT_TOGGLEBUTTON, lambda event: self.start_cutting_tool(event, "y", 1))
+        axis_sizer.Add(cutyplusbutton, 1, wx.EXPAND | wx.RIGHT, getSpace('mini'))
+        cutzplusbutton = wx.ToggleButton(self.menupanel, label = _("+Z"), style = wx.BU_EXACTFIT)
+        cutzplusbutton.Bind(wx.EVT_TOGGLEBUTTON, lambda event: self.start_cutting_tool(event, "z", 1))
+        axis_sizer.Add(cutzplusbutton, 1, wx.EXPAND | wx.RIGHT, getSpace('mini'))
+        cutxminusbutton = wx.ToggleButton(self.menupanel, label = _("-X"), style = wx.BU_EXACTFIT)
+        cutxminusbutton.Bind(wx.EVT_TOGGLEBUTTON, lambda event: self.start_cutting_tool(event, "x", -1))
+        axis_sizer.Add(cutxminusbutton, 1, wx.EXPAND | wx.RIGHT, getSpace('mini'))
+        cutyminusbutton = wx.ToggleButton(self.menupanel, label = _("-Y"), style = wx.BU_EXACTFIT)
+        cutyminusbutton.Bind(wx.EVT_TOGGLEBUTTON, lambda event: self.start_cutting_tool(event, "y", -1))
+        axis_sizer.Add(cutyminusbutton, 1, wx.EXPAND | wx.RIGHT, getSpace('mini'))
+        cutzminusbutton = wx.ToggleButton(self.menupanel, label = _("-Z"), style = wx.BU_EXACTFIT)
+        cutzminusbutton.Bind(wx.EVT_TOGGLEBUTTON, lambda event: self.start_cutting_tool(event, "z", -1))
+        axis_sizer.Add(cutzminusbutton, 1, flag = wx.EXPAND)
+
+        cutsizer.Add(wx.StaticText(self.menupanel, -1, _("Choose axis to cut along:")), 0, wx.BOTTOM, getSpace('minor'))
+        cutsizer.Add(axis_sizer, 0, wx.EXPAND, wx.BOTTOM, getSpace('minor'))
+        cutsizer.Add(wx.StaticText(self.menupanel, -1, _("Doubleclick to set the cutting plane.")), 0, wx.TOP | wx.BOTTOM, getSpace('minor'))
+        # Process cut button
+        cut_processbutton = wx.Button(self.menupanel, label = _("Process Cut"))
+        cut_processbutton.Bind(wx.EVT_BUTTON, self.cut_confirm)
+        cut_processbutton.Disable()
+        self.cut_processbutton = cut_processbutton
+        cutsizer.Add(cut_processbutton, 0, flag = wx.EXPAND)
+
+        #self.menupanel.SetSizer(cutsizer)
+        nrows = self.menusizer.GetRows()
+        self.menusizer.Add(cutsizer, pos = (nrows, 0), span = (1, 1), 
+                            flag = wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, border = getSpace('mini'))
+    
     def start_cutting_tool(self, event, axis, direction):
         toggle = event.EventObject
         self.cutting = toggle.Value
@@ -481,8 +484,8 @@ class StlPlaterPanel(PlaterPanel):
                                                 model.filename))
                 model = model.transform(transformation_matrix(model))
                 facets += model.facets
-            logging.error("The function 'stltool.emitstl' has been deactivated due to an unresolved bug.")
-            #stltool.emitstl(name, facets, "plater_export") #this brakes atm
+            #logging.error("The function 'stltool.emitstl' has been deactivated due to an unresolved bug.")
+            stltool.emitstl(name, facets, "plater_export") # FIXME: this brakes atm?
             logging.info(_("Wrote plate to %s") % name)
 
     def autoplate(self, event = None):


### PR DESCRIPTION
Good Evening. It took a little longer than expected, I had to dig a bit deeper for some things. With this PR I continue to refine the ui of Pronterface. 
Example Plater:
![230419_plater](https://user-images.githubusercontent.com/118119547/234345868-9786c999-315c-422d-a779-5bac8f5a5127.jpg)
Example Spool Manager:
![230419_spoolmanager](https://user-images.githubusercontent.com/118119547/234345893-9941c226-4762-475f-a2c4-7ed10e203c4e.jpg)

This was tested on MacOS and Windows, just like last time. I used real files and tried to test all situations I could think of. Here's a non-exhaustive list of changes, but it's probably better to look at the tools directly:

STL and G-Code Plater
- layout update
- groups and structures that make it easier to understand
- added StdDialogButtons
- buttons are greyed out when not available
- changed the way the 'Cutting Tool' is loaded

Excluder + G-Code Viewer:
- minor layout update
- added 'Close' button to toolbar
- rearranged buttons in the toolbar
- made sure the right toolbar is loaded
- added SetTitle for Excluder

ProjectLayer Control
- minor layout update
- added 'Reset' and 'Close' buttons
- added the 'reset defaults' feature
- buttons are greyed out when not available
- added gettext markups for all strings!
- added a 'Status' to the infobox and send now all former 'print' to that
- added warning when a value is not valid
- 'Direction' setting saves now the index and not the string of the choice
- fixed 'Calibrate' feature, expected integer
- fixed 'First Layer' feature, expected integer

SpoolManager
- resized and optimised main dialog
- fixed dark grey background
- combined statusbar and 'Close' button
- buttons are greyed out when not available
- layout update of 'Add Spool'
- rearranged layout of 'Edit Spool'
- use modal dialog for add and edit

I hope you like the changes. If so, I have plenty of ideas for further improvements.