### PR TITLE
p/pronterface: Fix unknown wx locale

### DIFF
--- a/printrun/pronterface.py
+++ b/printrun/pronterface.py
@@ -2578,6 +2578,10 @@ class PronterApp(wx.App):
     def __init__(self, *args, **kwargs):
         super(PronterApp, self).__init__(*args, **kwargs)
         self.SetAppName("Pronterface")
-        self.locale = wx.Locale(wx.Locale.GetSystemLanguage())
+        lang = wx.Locale.GetSystemLanguage()
+        # Fall back to English if unable to determine language
+        if lang == wx.LANGUAGE_UNKNOWN:
+            lang = wx.LANGUAGE_ENGLISH_US
+        self.locale = wx.Locale(lang)
         self.mainwindow = PronterWindow(self)
         self.mainwindow.Show()


### PR DESCRIPTION
Function `wx.Locale.GetSystemLanguage` returns `wx.LANGUAGE_UNKNOWN` when unable to identify the system's language. And `wx.Locale` constructor does not allow `wx.LANGUAGE_UNKNOWN` as an argument.

Fixes #1345
Fixes #1348

CC @DivingDuck @neofelis2X could you give this a try and confirm it works?