### PR TITLE
Release Printrun 2.0.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+Printrun - 2.0.1
+================
+
+Patch release. Dropped support for Python 3.6 wheels and macOS 10.
+
+### Fixed Bugs
+
+ - C++ assertion error due to unknown locale (#1351)
+
+
 Printrun - 2.0.0
 ====================
 

--- a/printrun/printcore.py
+++ b/printrun/printcore.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Printrun.  If not, see <http://www.gnu.org/licenses/>.
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 import sys
 if sys.version_info.major < 3:


### PR DESCRIPTION
Up for debate as always. My plan was to release this bit with only the fix on #1351. All other additions to be included on a future 2.1.0 release once they've been more thoroughly tested. Please speak up if you know any major blockers.