### PR TITLE
trivial: fix typo in desktop file

### DIFF
--- a/pronsole.desktop
+++ b/pronsole.desktop
@@ -2,7 +2,7 @@
 Type=Application
 Name=Pronsole
 GenericName=Printer console
-Comment=Controls your 3D printer form console
+Comment=Controls your 3D printer from the console
 Icon=pronsole
 Exec=/usr/bin/pronsole.py
 StartupNotify=true


### PR DESCRIPTION
Tiny fix for a typo in the `.desktop` file for Pronsole (which is noticeable when using a launcher, etc)