### PR TITLE
enable parity workaround for Linux systems

### DIFF
--- a/printrun/printcore.py
+++ b/printrun/printcore.py
@@ -171,7 +171,7 @@ class printcore():
         # don't support it.  Limit it to platforms that actually require it
         # here to avoid doing redundant work elsewhere and potentially breaking
         # things.
-        self.needs_parity_workaround = platform.system() == "linux" and os.path.exists("/etc/debian")
+        self.needs_parity_workaround = platform.system() == "Linux"
         for handler in self.event_handler:
             try: handler.on_init()
             except: logging.error(traceback.format_exc())


### PR DESCRIPTION
On some systems, the serial port needs to set odd/even parity on connecting, before reverting to no parity during operation. Otherwise, the connection is flaky and often stops working after the first command.
This serial port parity workaround is not limited to Debian-based systems, but extends to other Linux distributions, too (e.g. Arch). Also, platform.system() is "Linux" on those systems, not "linux".