### PR TITLE
Projectlayer: Some maintenance and improvement

### DIFF
--- a/printrun/projectlayer.py
+++ b/printrun/projectlayer.py
@@ -53,6 +53,9 @@ class DisplayFrame(wx.Frame):
         self.CentreOnParent()
         self.Show()
 
+        # Closing the DisplayFrame calls the close method of Settingsframe
+        self.Bind(wx.EVT_CLOSE, parent.on_close)
+
         self.scale = scale
         self.index = 0
         self.size = res


### PR DESCRIPTION
Hello. A while ago I spent some time on the Projectlayer module. The more I work on it, the more I realise how incomplete and buggy it is. I think I've fixed some of the problems, but it is far from being a useable feature.

- Projectlayer has been renamed to **Layer Projector**. Makes more sense to me.

- Changed the way files are loaded and made sure all supported file formats work as expected. Now only _layered_ .svg files can be loaded, normal .svgs are rejected. This fixes #1360

- The Layer Projector can now load **Prusaslicer SL1 and SL1S** files! If you want to try it, you probably have to use a 'Scale' of 0.6 or so, because they have a higher resolution. One of the examples I used was this file:
https://www.printables.com/model/297351-m3-nut-for-2020-5mm-profile/files

- Closing one of the two windows now closes the other as well.

- Perhaps the most important change: **cairosvg has been replaced by wx.svg**, which already comes with wxpython. This saves the extra dependency on that library. After comparing the output of the two libraries, I can confirm that wx.svg produces pixel-perfect the same result as cairosvg.

Tested on python win 3.10, mac 3.11 and 3.7.9.