### PR TITLE
[WIP] Gcode scrolling / stepping / skipping

### DIFF
--- a/printrun/printcore.py
+++ b/printrun/printcore.py
@@ -155,7 +155,7 @@ class printcore():
         self.startcb = None  # impl ()
         self.endcb = None  # impl ()
         self.onlinecb = None  # impl ()
-        self.loud = True  # emit sent and received lines to terminal
+        self.loud = False  # emit sent and received lines to terminal
         self.tcp_streaming_mode = False
         self.greetings = ['start', 'Grbl ']
         self.wait = 0  # default wait period for send(), send_now()


### PR DESCRIPTION
I am using Printrun to control a DIY embroidery machine.

Stepping / skipping through an embroidery file is a standard feature on embroidery machines, and also on most CNC systems.

I have created a quick and dirty implementation of this, that allows to do the following (in pronsole only for now):

* `line` command that shows the next G-Code line to be sent and surrounding lines
* `start pause` command that starts the print in paused state
* `skip` command that allows to skip lines forward / backward in the G-Code file
* `next`  command that exposes `send_next` to send a single line of G-Code from the G-Code file
* Resume without restore so that the print can be resumed directly as previewed by `line`

This is currently very messy and a clean implementation would have to involve "pulling apart" and making the state machine of a print being live / paused a little more complex.

Please let me know if this is something you'd like to add to Printrun and I can spend time to clean it up.