### PR TITLE
host: Add commands for the host to send feedback for resume/cancel print to process_host_command

### DIFF
--- a/printrun/printcore.py
+++ b/printrun/printcore.py
@@ -594,10 +594,14 @@ class printcore():
             self._start_sender()
 
     def process_host_command(self, command):
-        """only ;@pause command is implemented as a host command in printcore, but hosts are free to reimplement this method"""
+        """only ;@pause, ;@cancel and ;@resume commands are implemented as a host command in printcore, but hosts are free to reimplement this method"""
         command = command.lstrip()
         if command.startswith(";@pause"):
             self.pause()
+        elif command.startswith(";@cancel"):
+            self.cancelprint()
+        elif command.startswith(";@resume"):
+            self.resume()
 
     def _sendnext(self):
         if not self.printer:


### PR DESCRIPTION
This adds additional commands needed for printer safety.
For printers that are canceling the print, the print should not continue but stop instead.
If the user interacts with the printer, there is a need also to be able to also resume the print after the user resumed on the printer.

Implementation will take part for Prusa printers after the PR has been accepted and merged (see PR here: https://github.com/prusa3d/Prusa-Firmware-Buddy/pull/3763)