### PR TITLE
Add "cancel" command in order to cancel print on Prusa / Marlin based Printers

### DIFF
--- a/printrun/pronsole.py
+++ b/printrun/pronsole.py
@@ -1316,7 +1316,7 @@ class pronsole(cmd.Cmd):
                 command = command.split(":")
                 if len(command) == 2 and command[0] == "action":
                     command = command[1]
-                    if command == "pause":
+                    if command in ["pause", "cancel"]:
                         self.do_pause(None)
                         sys.stdout.write(self.promptf())
                         sys.stdout.flush()

--- a/printrun/pronterface.py
+++ b/printrun/pronterface.py
@@ -2055,7 +2055,7 @@ Printrun. If not, see <http://www.gnu.org/licenses/>."""
                 if len(command) == 2 and command[0] == "action":
                     command = command[1]
                     self.log(_("Received command %s") % command)
-                    if command == "pause":
+                    if command in ["pause", "cancel"]:
                         if not self.paused:
                             wx.CallAfter(self.pause)
                         return True


### PR DESCRIPTION
On printing via Printrun on Prusa and Marlin based printers, if the user stops the print on the printer, Printrun will continue to print and doesn't recognize that the print run was canceled. The Prusa / Marlin based printers are sending the "action:cancel" (see [here](https://github.com/prusa3d/Prusa-Firmware-Buddy/blob/b3ee47aa573f4d9b4af82d7a6963f43ab37ccc08/src/common/serial_printing.cpp#L13) and [here](https://github.com/MarlinFirmware/Marlin/blob/9e879a5b1f801e7572e7948be38a6dad16ad35d8/Marlin/src/feature/host_actions.cpp#L64)) command via serial port, but Printcore seems to expect "!!". This commit adds the "action:cancel" command support.

I'm not sure if pause is the right command, but I couldn't see any stop implementation. 