### PR TITLE
Replace configparser readfp with read_file

### DIFF
--- a/printrun/pronterface.py
+++ b/printrun/pronterface.py
@@ -2559,7 +2559,7 @@ Printrun. If not, see <http://www.gnu.org/licenses/>."""
                 import itertools
                 return itertools.chain([self.header], iter(self.f))
 
-        parser.readfp(add_header(open(configfile)), configfile)
+        parser.read_file(add_header(open(configfile)), configfile)
         return parser
 
     def set_slic3r_config(self, configfile, cat, file):


### PR DESCRIPTION
readfp() was [deprecated in Python 3.2][1] and [removed in Python 3.12][2]. read_file() is a drop-in replacement.

[1]: https://github.com/python/cpython/blob/dd0e8a62df8be2a09ef6035b4c92bd9a68a7b918/Lib/configparser.py#L757-L764
[2]: https://github.com/python/cpython/commit/1fc41ae8709e20d741bd86c2345173688a5e84b0

Fixes this error with Python 3.12:
```
Traceback (most recent call last):
  File "/usr/bin/pronterface.py", line 62, in <module>
    app = PronterApp(False)
          ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/printrun/pronterface.py", line 2596, in __init__
    self.mainwindow = PronterWindow(self)
                      ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/printrun/pronterface.py", line 220, in __init__
    self.reload_ui()
  File "/usr/lib/python3.12/site-packages/printrun/pronterface.py", line 288, in reload_ui
    self.create_menu()
  File "/usr/lib/python3.12/site-packages/printrun/pronterface.py", line 862, in create_menu
    self.load_slic3r_configs(menus)
  File "/usr/lib/python3.12/site-packages/printrun/pronterface.py", line 2517, in load_slic3r_configs
    config = self.read_slic3r_config(configfile)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/printrun/pronterface.py", line 2562, in read_slic3r_config
    parser.readfp(add_header(open(configfile)), configfile)
    ^^^^^^^^^^^^^
AttributeError: 'RawConfigParser' object has no attribute 'readfp'. Did you mean: 'read'?
```