### PR TITLE
ci: Automate uploading of assets on releases

### DIFF
--- a/.github/workflows/buildpackage-mac.yml
+++ b/.github/workflows/buildpackage-mac.yml
@@ -56,22 +56,22 @@ jobs:
     - name: Configuration for releases
       if: ${{ github.event_name == 'release' }}
       run: |
-        echo "EXE_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
+        echo "EXE_NAME=${{ github.ref_name }}_macos_${{ matrix.architecture }}" >> $GITHUB_ENV
 
     - name: Configuration for pushes
       if: ${{ github.event_name == 'push' }}
       run: |
-        echo "EXE_NAME=printrun-nightly" >> $GITHUB_ENV
+        echo "EXE_NAME=printrun-nightly_${{ matrix.os }}_${{ matrix.architecture }}_py${{ matrix.python-version }}" >> $GITHUB_ENV
 
     - name: Configuration for pull requests
       if: ${{ github.event_name == 'pull_request' }}
       run: |
-        echo "EXE_NAME=printrun-test" >> $GITHUB_ENV
+        echo "EXE_NAME=printrun-test_${{ matrix.os }}_${{ matrix.architecture }}_py${{ matrix.python-version }}" >> $GITHUB_ENV
 
     - name: Upload artifacts for inspection
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ env.EXE_NAME }}_${{ matrix.os }}_${{ matrix.architecture }}_py${{ matrix.python-version }}
+        name: ${{ env.EXE_NAME }}
         path: dist/Pronterface-app.zip
 
   upload_release_assets:

--- a/.github/workflows/buildpackage-mac.yml
+++ b/.github/workflows/buildpackage-mac.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   release:
     types:
-      - created
+      - published
 
 jobs:
   build:
@@ -64,7 +64,7 @@ jobs:
         echo "EXE_NAME=printrun-nightly" >> $GITHUB_ENV
 
     - name: Configuration for pull requests
-      if: ${{ github.event_name != 'release' && github.event_name != 'push' }}
+      if: ${{ github.event_name == 'pull_request' }}
       run: |
         echo "EXE_NAME=printrun-test" >> $GITHUB_ENV
 
@@ -73,3 +73,8 @@ jobs:
       with:
         name: ${{ env.EXE_NAME }}_${{ matrix.os }}_${{ matrix.architecture }}_py${{ matrix.python-version }}
         path: dist/Pronterface-app.zip
+
+  upload_release_assets:
+    needs: [build]
+    if: github.event_name == 'release' && github.event.action == 'published'
+    uses: kliment/Printrun/.github/workflows/upload-assets.yml@master

--- a/.github/workflows/buildpackage-win.yml
+++ b/.github/workflows/buildpackage-win.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   release:
     types:
-      - created
+      - published
 
 jobs:
   build:
@@ -76,7 +76,7 @@ jobs:
         "EXE_NAME=printrun-nightly" >> $env:GITHUB_ENV
 
     - name: Configuration for pull requests
-      if: ${{ github.event_name != 'release' && github.event_name != 'push' }}
+      if: ${{ github.event_name == 'pull_request' }}
       run: |
         "EXE_NAME=printrun-test" >> $env:GITHUB_ENV
 
@@ -88,3 +88,8 @@ jobs:
             dist/Pronterface.exe 
             dist/Pronsole.exe
             dist/locale
+
+  upload_release_assets:
+    needs: [build]
+    if: github.event_name == 'release' && github.event.action == 'published'
+    uses: kliment/Printrun/.github/workflows/upload-assets.yml@master

--- a/.github/workflows/upload-assets.yml
+++ b/.github/workflows/upload-assets.yml
@@ -1,0 +1,40 @@
+name: Upload Assets to Releases
+
+on:
+  workflow_call:
+
+jobs:
+  upload_release_assets:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      checks: write
+      actions: read
+      issues: read
+      packages: write
+      pull-requests: read
+      repository-projects: read
+      statuses: read
+    steps:
+      - name: Get artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: printrun-*
+          path: upload
+          merge-multiple: false
+
+      - name: Zip artifacts for uploading
+        run: |
+          cd upload || { echo "Failed to cd into 'upload'"; exit 1; }
+          for i in *; do
+            cd "$i" || { echo "Failed to cd into '$i'"; exit 1; }
+            zip -r "../$i.zip" ./*
+            cd ..
+          done
+
+      - name: Upload assets
+        uses: alexellis/upload-assets@0.4.1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          asset_paths: '["upload/*.zip"]'


### PR DESCRIPTION
Attempt to automate the uploading of artifacts on releases. As with any GitHub Actions stuff this has gone through limited testing and most likely won't be tested 100% until a new release is produced.