### PR TITLE
ci: Add support for Python 3.13 on builds

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -29,9 +29,9 @@ jobs:
         env:
           # we only support what's supported by wxPython, therefore we skip:
           #  * PyPy Python implementation
-          #  * Python 3.6, 3.7 and 3.13 versions
+          #  * Python 3.6 and 3.7 versions
           #  * musl C implementation
-          CIBW_SKIP: "pp* cp36* cp37* cp313* *-musllinux*"
+          CIBW_SKIP: "pp* cp36* cp37* *-musllinux*"
           # produce ARM wheels on Linux in addition to 32 and 64 bit
           CIBW_ARCHS_LINUX: auto aarch64
           # produce wheels for macOS to support both Intel and Apple silicon

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,8 +55,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13-dev"]
         # Unit testing uses functions not available on Python < 3.11
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4
@@ -65,6 +65,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Install Printrun dependencies for unit testing
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ classifiers=[
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Printing",
 ]
 dynamic = [  # these variables are dynamically set at `setup.py`


### PR DESCRIPTION
wxPython 4.2.2 added support for Python 3.13 and therefore we can now enable builds for it as well.