### PR TITLE
Replace module imghdr with puremagic

### DIFF
--- a/printrun/projectlayer.py
+++ b/printrun/projectlayer.py
@@ -20,7 +20,7 @@ import os
 import time
 import zipfile
 import tempfile
-import imghdr
+import puremagic
 import copy
 import re
 from collections import OrderedDict
@@ -756,7 +756,7 @@ class SettingsFrame(wx.Dialog):
 
         for f in imagefilesOrderedDict.values():
             path = os.path.join(self.image_dir.name, f)
-            if os.path.isfile(path) and imghdr.what(path) in accepted_image_types:
+            if os.path.isfile(path) and puremagic.what(path) in accepted_image_types:
                 ol.append(path)
 
         return ol, -1, 'Bitmap'
@@ -780,7 +780,7 @@ class SettingsFrame(wx.Dialog):
         ol = []
         for f in sorted(os.listdir(self.image_dir.name)):
             path = os.path.join(self.image_dir.name, f)
-            if os.path.isfile(path) and imghdr.what(path) in accepted_image_types:
+            if os.path.isfile(path) and puremagic.what(path) in accepted_image_types:
                 ol.append(path)
 
         return ol, -1, 'PrusaSlicer', settings

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ pyglet >= 1.1, < 2.0
 psutil (>= 2.1)
 lxml (>= 2.9.1)
 platformdirs
+puremagic
 dbus-python >= 1.2.0 ; sys_platform == 'linux'
 pyobjc-framework-Cocoa ; sys_platform == 'darwin'
 pyreadline3 ; sys_platform == 'win32'


### PR DESCRIPTION
Replace module imghdr with puremagic as it becomes obsolete with Python 3.13

Pls. see issue #1453 for details

