### PR TITLE
ci: Fix missing system dep on functional tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt update
-          sudo apt install -y libdbus-1-dev libgtk-3-0 libxxf86vm1 libnotify4 libsdl2-2.0-0 libsm6 libpcre2-32-0
+          sudo apt install -y libglib2.0-dev libdbus-1-dev libgtk-3-0 libxxf86vm1 libnotify4 libsdl2-2.0-0 libsm6 libpcre2-32-0
 
       - name: Install Printrun dependencies
         run: |


### PR DESCRIPTION
Tests failed with the following error when building dbus-python:

```
../subprojects/dbus-gmain/meson.build:108:11: ERROR: Dependency "glib-2.0" not found, tried pkgconfig and cmake
```