### PR TITLE
pyglet: disable shadow_window

### DIFF
--- a/printrun/gl/panel.py
+++ b/printrun/gl/panel.py
@@ -24,6 +24,7 @@ from wx import glcanvas
 
 import pyglet
 pyglet.options['debug_gl'] = True
+pyglet.options['shadow_window'] = False
 
 from pyglet.gl import glEnable, glDisable, GL_LIGHTING, glLightfv, \
     GL_LIGHT0, GL_LIGHT1, GL_LIGHT2, GL_POSITION, GL_DIFFUSE, \


### PR DESCRIPTION
It looks like on linux/X11 pyglet's shadow_window conflicts with wxWidget's GLContext. Since pronterface can't make use of it anway, it makes sense to just disable it.

Bug: https://github.com/kliment/Printrun/issues/1390