### PR TITLE
Fix typos in the messages shown when serial connection fails

### DIFF
--- a/printrun/device.py
+++ b/printrun/device.py
@@ -281,7 +281,7 @@ class Device():
         try:
             self._device.write(data)
         except serial.SerialException as e:
-            msg = "Unable to write to serial port '{self.port}'"
+            msg = f"Unable to write to serial port '{self.port}'"
             raise DeviceError(msg, e) from e
 
     def _disable_ttyhup(self):

--- a/printrun/printcore.py
+++ b/printrun/printcore.py
@@ -158,7 +158,7 @@ class printcore():
     def addEventHandler(self, handler):
         '''
         Adds an event handler.
-        
+
         @param handler: The handler to be added.
         '''
         self.event_handler.append(handler)
@@ -707,5 +707,5 @@ class printcore():
                 self.writefailures = 0
             except device.DeviceError as e:
                 self.logError("Can't write to printer (disconnected?)"
-                              "{0}".format(e))
+                              " {0}".format(e))
                 self.writefailures += 1


### PR DESCRIPTION
- fix a missing "f" in an f-string
- fix a missing space in a string that is split onto two lines

HTH :slightly_smiling_face: 