### PR TITLE
macOS reference from the README to the wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,9 @@ repositories or from PyPI. If you want the newest, shiniest features, you can
 Everything bundled into one single package for easy installation. Downloads
 available at: https://github.com/kliment/Printrun/releases/latest
 
-> **Note for OSX users**: if OSX tells you `"pronterface.app" cannot be opened
-> because the developer cannot be verified.`, you don't need to re-download
-> it. Instead, you need to allow OSX to run the unsigned app. To do this,
-> right- or ctrl click the application in Finder and select `Open`. Then click `Open`
-> in the popup window that appears. You only need to do this once.
+#### Important: Allow the application to run on macOS
 
+macOS will block Printrun from running because it is not from a verified developer. [Please read this wiki article](https://github.com/kliment/Printrun/wiki/macOS-Apple-could-not-verify) to learn how to allow the application to start. You only need to do this once for each new version.
 
 ### Linux packages from official repositories
 

--- a/buildinstructions.md
+++ b/buildinstructions.md
@@ -86,8 +86,11 @@ pyi-makespec -F --add-data images/*;images --add-data *.png;. --add-data *.ico;.
 pyinstaller --clean pronterface.spec -y
 ```
 
->[!TIP] Please find further informations about building a development environment and packaging in script [release_windows.bat](release_windows.bat) where we implemented an automated build for windows.
+> [!TIP]
+> Please find further informations about building a development environment and packaging in script [release_windows.bat](release_windows.bat) where we implemented an automated build for windows.
 
-### Remark: 
->[^1]: The library **polygon3** is free for non commercial use. You can build Pronterface without this library - but then it will run slower.
->Please find further details regarding license here: https://pypi.org/project/Polygon3/
+### Remark:
+
+[^1]: The library **polygon3** is free for non commercial use. You can build Pronterface without this library - but then it will run slower.
+  Please find further details regarding license here: https://pypi.org/project/Polygon3/
+


### PR DESCRIPTION
Hi,

I updated the wiki with instructions how to unblock the newly downloaded application on macOS. This PR simply adds a link to readme which leads the users to the wiki.